### PR TITLE
[feat]  layout 공통 컴포넌트 구현 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,115 +1,11 @@
-import styled from '@emotion/styled';
+import { Layout } from './layout/Layout';
 
 function App() {
   return (
-    <Page>
-      <Card>
-        <Badge>공용 스타일 테스트</Badge>
-
-        <Title>지켜줘 홈즈</Title>
-        <Description>
-          공통 색상, radius, shadow, font가 Emotion theme으로 잘 적용되는지
-          확인하는 화면입니다.
-        </Description>
-
-        <ButtonGroup>
-          <PrimaryButton>primary 버튼</PrimaryButton>
-          <SecondaryButton>secondary 버튼</SecondaryButton>
-        </ButtonGroup>
-
-        <InfoBox>
-          <strong>전역 스타일 확인</strong>
-          <p>
-            배경색, 카드 색상, border, radius, shadow가 적용되는지 확인하세요.
-          </p>
-        </InfoBox>
-      </Card>
-    </Page>
+    <Layout>
+      <div>레이아웃 테스트</div>
+    </Layout>
   );
 }
 
 export default App;
-
-const Page = styled.main`
-  min-height: 100vh;
-  padding: 40px 20px;
-  background-color: ${({ theme }) => theme.colors.bg};
-  color: ${({ theme }) => theme.colors.text};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-const Card = styled.section`
-  width: 100%;
-  max-width: 420px;
-  padding: 28px;
-  border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: ${({ theme }) => theme.radius.xl};
-  background-color: ${({ theme }) => theme.colors.surface};
-  box-shadow: ${({ theme }) => theme.shadow.card};
-`;
-
-const Badge = styled.span`
-  display: inline-flex;
-  padding: 6px 10px;
-  border-radius: ${({ theme }) => theme.radius.full};
-  background-color: ${({ theme }) => theme.colors.primarySoft};
-  color: ${({ theme }) => theme.colors.primaryDark};
-  font-size: 13px;
-  font-weight: 700;
-`;
-
-const Title = styled.h1`
-  margin: 18px 0 8px;
-  color: ${({ theme }) => theme.colors.text};
-  font-size: 32px;
-  line-height: 1.2;
-`;
-
-const Description = styled.p`
-  color: ${({ theme }) => theme.colors.textSub};
-  line-height: 1.6;
-`;
-
-const ButtonGroup = styled.div`
-  display: flex;
-  gap: 10px;
-  margin-top: 24px;
-`;
-
-const PrimaryButton = styled.button`
-  flex: 1;
-  padding: 12px 14px;
-  border-radius: ${({ theme }) => theme.radius.md};
-  background-color: ${({ theme }) => theme.colors.primary};
-  color: ${({ theme }) => theme.colors.surface};
-  font-weight: 700;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.primaryDark};
-  }
-`;
-
-const SecondaryButton = styled.button`
-  flex: 1;
-  padding: 12px 14px;
-  border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: ${({ theme }) => theme.radius.md};
-  background-color: ${({ theme }) => theme.colors.primarySoft};
-  color: ${({ theme }) => theme.colors.primary};
-  font-weight: 700;
-`;
-
-const InfoBox = styled.div`
-  margin-top: 20px;
-  padding: 16px;
-  border-radius: ${({ theme }) => theme.radius.lg};
-  background-color: ${({ theme }) => theme.colors.warningBg};
-  color: ${({ theme }) => theme.colors.textSub};
-
-  p {
-    margin-top: 6px;
-    line-height: 1.5;
-  }
-`;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+import type { ReactNode } from 'react';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export function Layout({ children }: LayoutProps) {
+  return (
+    <Wrapper>
+      <LayoutWrapper>{children}</LayoutWrapper>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+`;
+
+const LayoutWrapper = styled.main`
+  width: 100%;
+  max-width: 420px;
+  min-height: 100vh;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background-color: ${({ theme }) => theme.colors.surface};
+`;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -14,7 +14,7 @@ export function Layout({ children }: LayoutProps) {
 }
 
 const Wrapper = styled.div`
-  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   justify-content: center;
 `;
@@ -23,10 +23,10 @@ const LayoutWrapper = styled.main`
   width: 100%;
   max-width: 420px;
   min-width: 320px;
-  min-height: 100vh;
+  min-height: 100dvh;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-x: hidden;
   background-color: ${({ theme }) => theme.colors.surface};
 `;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -22,6 +22,7 @@ const Wrapper = styled.div`
 const LayoutWrapper = styled.main`
   width: 100%;
   max-width: 420px;
+  min-width: 320px;
   min-height: 100vh;
   margin: 0 auto;
   display: flex;


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #18 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 30min
- 실제 작업 시간 : 30min

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- 화면을 가운데 정렬하는 Wrapper 구성
- 최대 너비 420px 기준의 웹 앱 구조 설계
- 최소 너비(320px) 추가하여 레이아웃 깨짐 방지
- 모든 페이지가 동일한 레이아웃 구조를 사용할 수 있도록 기반 구성

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="1277" height="722" alt="image" src="https://github.com/user-attachments/assets/f4b20635-3c67-4c08-a6c3-ab97c7cc5808" />


<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- [트러블 슈팅1](링크)

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

Layout 자체에 padding을 주면 Header 영역까지 함께 안쪽으로 밀려서, 헤더의 전체 너비 배치에 영향을 줄 수 있을 것 같아요.
그래서 Header는 기존처럼 전체 레이아웃 폭을 기준으로 유지하고, Header 아래 실제 페이지 내용이 들어가는 영역만 별도 컴포넌트로 분리해서 padding을 적용하려고 합니다.
이후 App.tsx에서는 Layout 안에 Header와 콘텐츠 영역 컴포넌트를 함께 배치하는 구조로 가져가겠습니다.

<br />

## 📘 참고

- ⚠️ 이전 커밋 rebase로 머지하기,,,!!!
