### PR TITLE
[feat] 태그 공통컴포넌트 구현

### DIFF
--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import styled from '@emotion/styled';
+import { theme } from '../../styles/theme';
+
+type TagVariant = 'success' | 'warning' | 'danger';
+
+interface TagProps {
+  variant: TagVariant;
+  children: ReactNode;
+}
+
+export function Tag({ variant, children, ...props }: TagProps) {
+  return (
+    <TagContainer $variant={variant} {...props}>
+      {children}
+    </TagContainer>
+  );
+}
+
+const TAG_COLORS = {
+  success: {
+    color: theme.colors.success,
+    background: theme.colors.successBg,
+  },
+  warning: {
+    color: theme.colors.warning,
+    background: theme.colors.warningBg,
+  },
+  danger: {
+    color: theme.colors.danger,
+    background: theme.colors.dangerBg,
+  },
+} as const;
+
+const TagContainer = styled.div<{ $variant: TagVariant }>`
+  display: inline-block;
+  align-items: center;
+  gap: 4px;
+  justify-content: center;
+  flex-shrink: 0;
+  color: ${({ $variant }) => TAG_COLORS[$variant].color};
+  background: ${({ $variant }) => TAG_COLORS[$variant].background};
+
+  svg {
+    width: 15px;
+    height: 15px;
+    flex-shrink: 0;
+  }
+`;

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -1,45 +1,36 @@
-import type { ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import styled from '@emotion/styled';
-import { theme } from '../../styles/theme';
+import { TAG_COLORS, type TagVariant } from '../../constants/tag';
 
-type TagVariant = 'success' | 'warning' | 'danger';
-
-interface TagProps {
+interface TagProps extends HTMLAttributes<HTMLSpanElement> {
   variant: TagVariant;
   children: ReactNode;
 }
 
-export function Tag({ variant, children, ...props }: TagProps) {
+export function Tag({ variant, children, ...rest }: TagProps) {
   return (
-    <TagContainer $variant={variant} {...props}>
+    <TagContainer $variant={variant} {...rest}>
       {children}
     </TagContainer>
   );
 }
 
-const TAG_COLORS = {
-  success: {
-    color: theme.colors.success,
-    background: theme.colors.successBg,
-  },
-  warning: {
-    color: theme.colors.warning,
-    background: theme.colors.warningBg,
-  },
-  danger: {
-    color: theme.colors.danger,
-    background: theme.colors.dangerBg,
-  },
-} as const;
-
-const TagContainer = styled.div<{ $variant: TagVariant }>`
-  display: inline-block;
+const TagContainer = styled.span<{
+  $variant: TagVariant;
+}>`
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
   justify-content: center;
   flex-shrink: 0;
-  color: ${({ $variant }) => TAG_COLORS[$variant].color};
-  background: ${({ $variant }) => TAG_COLORS[$variant].background};
+  line-height: 1;
+  padding: 2px 9px;
+  font-size: 11px;
+  font-weight: 600;
+  height: 22px;
+  border-radius: ${({ theme }) => theme.radius.full};
+  color: ${({ theme, $variant }) => theme.colors[TAG_COLORS[$variant].color]};
+  background: ${({ theme, $variant }) =>
+    theme.colors[TAG_COLORS[$variant].background]};
 
   svg {
     width: 15px;

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -1,0 +1,16 @@
+export type TagVariant = 'success' | 'warning' | 'danger';
+
+export const TAG_COLORS = {
+  success: {
+    color: 'success',
+    background: 'successBg',
+  },
+  warning: {
+    color: 'warning',
+    background: 'warningBg',
+  },
+  danger: {
+    color: 'danger',
+    background: 'dangerBg',
+  },
+} as const;


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #26 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- 태그(Tag) 공통 컴포넌트 생성
- `success`, `warning`, `danger` 상태별 스타일 적용
- 태그 색상 key를 constants로 분리하여 다른 컴포넌트에서도 재사용 가능하도록 구성
- 아이콘을 외부에서 children으로 전달할 수 있도록 구현
- Tag는 작은 상태 라벨 역할만 담당하도록 정리

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="157" height="25" alt="image" src="https://github.com/user-attachments/assets/e9ab91f6-2b08-4bce-aa3a-00a35b228a85" />


<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- [트러블 슈팅1](링크)

- Tag 컴포넌트가 작은 상태 라벨뿐만 아니라, count가 포함된 카드형 UI까지 담당해야 할지 고민했습니다.
- 특히 작은 태그와 카드형 요약 UI는 border-radius, 크기, 정렬 방식이 달라서 하나의 Tag 컴포넌트에서 props로 모두 제어하면 역할이 커질 수 있다고 판단했습니다.
- 그래서 Tag는 상태 라벨 역할에 집중하고, count가 필요한 카드형 UI는 추후 `StatusSummaryCard`로 분리하는 방향으로 정리했습니다.
- 대신 상태별 색상 기준은 함께 사용할 수 있도록 constants로 분리했습니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- 현재 props 구조가 적절한지 (확장성 / 사용성 관점)

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.

## 🐛 사용 예시

```tsx
<Tag variant="danger">주의 필요</Tag>

<Tag variant="warning">확인 권장</Tag>

<Tag variant="success">정상</Tag>
```
