### PR TITLE
[feat] 공통 Button 컴포넌트 구현 (#23)

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -9,12 +9,26 @@ const ICON_ONLY_SIZE: Record<Size, string> = {
   lg: '40px',
 };
 
+const BORDER_RADIUS: Record<Size, string> = {
+  sm: '8px',
+  md: '10px',
+  lg: '12px',
+};
+
+const ICON_SIZE: Record<Size, string> = {
+  sm: '14px',
+  md: '16px',
+  lg: '18px',
+};
+
 type Variant = 'primary' | 'outline' | 'ghost' | 'dashed';
 type Size = 'sm' | 'md' | 'lg';
+type GhostTone = 'blue' | 'black' | 'red';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: Variant;
   size?: Size;
+  tone?: GhostTone;
   iconStart?: ReactNode;
   iconEnd?: ReactNode;
   width?: CSSProperties['width'];
@@ -23,6 +37,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 export function Button({
   variant = 'primary',
   size = 'md',
+  tone = 'blue',
   iconStart,
   iconEnd,
   width,
@@ -35,6 +50,7 @@ export function Button({
     <StyledButton
       $variant={variant}
       $size={size}
+      $tone={tone}
       $isIconOnly={isIconOnly}
       $width={width}
       {...rest}
@@ -46,13 +62,14 @@ export function Button({
   );
 }
 
-function getVariantStyle($variant: Variant, theme: Theme) {
+function getVariantStyle($variant: Variant, $tone: GhostTone, theme: Theme) {
   switch ($variant) {
     case 'primary':
       return css`
         background: ${theme.colors.primary};
         color: ${theme.colors.surface};
-        &:hover:not(:disabled) {
+        &:hover:not(:disabled),
+        &:active:not(:disabled) {
           background: ${theme.colors.primaryDark};
         }
         &:disabled {
@@ -64,25 +81,39 @@ function getVariantStyle($variant: Variant, theme: Theme) {
         background: ${theme.colors.surface};
         color: ${theme.colors.text};
         border: 1px solid ${theme.colors.border};
-        &:hover:not(:disabled) {
+        &:hover:not(:disabled),
+        &:active:not(:disabled) {
           background: ${theme.colors.bg};
         }
       `;
-    case 'ghost':
+    case 'ghost': {
+      const GHOST_TONE: Record<GhostTone, { color: string; hoverBg: string }> =
+        {
+          blue: {
+            color: theme.colors.primary,
+            hoverBg: theme.colors.primarySoft,
+          },
+          black: { color: theme.colors.textSub, hoverBg: theme.colors.bg },
+          red: { color: theme.colors.danger, hoverBg: theme.colors.dangerBg },
+        };
+      const { color, hoverBg } = GHOST_TONE[$tone];
       return css`
         background: transparent;
-        color: ${theme.colors.primary};
+        color: ${color};
         padding: 0;
-        &:hover:not(:disabled) {
-          color: ${theme.colors.primaryDark};
+        &:hover:not(:disabled),
+        &:active:not(:disabled) {
+          background: ${hoverBg};
         }
       `;
+    }
     case 'dashed':
       return css`
         background: ${theme.colors.primarySoft};
         color: ${theme.colors.primary};
         border: 1px dashed ${theme.colors.primary};
-        &:hover:not(:disabled) {
+        &:hover:not(:disabled),
+        &:active:not(:disabled) {
           background: ${theme.colors.primaryLight};
         }
       `;
@@ -97,6 +128,11 @@ function getSizeStyle($size: Size, $isIconOnly: boolean) {
       height: ${dimension};
       padding: 0;
       flex-shrink: 0;
+      border-radius: ${BORDER_RADIUS[$size]};
+      svg {
+        width: ${ICON_SIZE[$size]};
+        height: ${ICON_SIZE[$size]};
+      }
     `;
   }
 
@@ -105,22 +141,34 @@ function getSizeStyle($size: Size, $isIconOnly: boolean) {
       return css`
         padding: 6px 10px;
         font-size: 12px;
-        border-radius: 8px;
+        border-radius: ${BORDER_RADIUS.sm};
         gap: 4px;
+        svg {
+          width: ${ICON_SIZE.sm};
+          height: ${ICON_SIZE.sm};
+        }
       `;
     case 'md':
       return css`
         padding: 8px 12px;
         font-size: 12px;
-        border-radius: 10px;
+        border-radius: ${BORDER_RADIUS.md};
         gap: 6px;
+        svg {
+          width: ${ICON_SIZE.md};
+          height: ${ICON_SIZE.md};
+        }
       `;
     case 'lg':
       return css`
         padding: 14px 20px;
         font-size: 15px;
-        border-radius: 12px;
+        border-radius: ${BORDER_RADIUS.lg};
         gap: 6px;
+        svg {
+          width: ${ICON_SIZE.lg};
+          height: ${ICON_SIZE.lg};
+        }
       `;
   }
 }
@@ -128,6 +176,7 @@ function getSizeStyle($size: Size, $isIconOnly: boolean) {
 const StyledButton = styled.button<{
   $variant: Variant;
   $size: Size;
+  $tone: GhostTone;
   $isIconOnly: boolean;
   $width?: CSSProperties['width'];
 }>`
@@ -144,7 +193,7 @@ const StyledButton = styled.button<{
     cursor: not-allowed;
   }
 
-  ${({ $variant, theme }) => getVariantStyle($variant, theme)}
+  ${({ $variant, $tone, theme }) => getVariantStyle($variant, $tone, theme)}
   ${({ $size, $isIconOnly }) => getSizeStyle($size, $isIconOnly)}
   ${({ $width }) =>
     $width &&

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -29,6 +29,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 export function Button({
+  type = 'button',
   variant = 'primary',
   size = 'md',
   tone = 'blue',
@@ -42,6 +43,7 @@ export function Button({
 
   return (
     <StyledButton
+      type={type}
       $variant={variant}
       $size={size}
       $tone={tone}
@@ -195,8 +197,8 @@ const StyledButton = styled.button<{
   ${({ $variant, $tone, theme }) => getVariantStyle($variant, $tone, theme)}
   ${({ $size, $isIconOnly, theme }) => getSizeStyle($size, $isIconOnly, theme)}
   ${({ $width }) =>
-    $width &&
+    $width != null &&
     css`
-      width: ${$width};
+      width: ${typeof $width === 'number' ? `${$width}px` : $width};
     `}
 `;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,154 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import type { Theme } from '@emotion/react';
+import type { CSSProperties, ReactNode, ButtonHTMLAttributes } from 'react';
+
+const ICON_ONLY_SIZE: Record<Size, string> = {
+  sm: '28px',
+  md: '32px',
+  lg: '40px',
+};
+
+type Variant = 'primary' | 'outline' | 'ghost' | 'dashed';
+type Size = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+  iconStart?: ReactNode;
+  iconEnd?: ReactNode;
+  width?: CSSProperties['width'];
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  iconStart,
+  iconEnd,
+  width,
+  children,
+  ...rest
+}: ButtonProps) {
+  const isIconOnly = !children && (!!iconStart || !!iconEnd);
+
+  return (
+    <StyledButton
+      $variant={variant}
+      $size={size}
+      $isIconOnly={isIconOnly}
+      $width={width}
+      {...rest}
+    >
+      {iconStart}
+      {children}
+      {iconEnd}
+    </StyledButton>
+  );
+}
+
+function getVariantStyle($variant: Variant, theme: Theme) {
+  switch ($variant) {
+    case 'primary':
+      return css`
+        background: ${theme.colors.primary};
+        color: ${theme.colors.surface};
+        &:hover:not(:disabled) {
+          background: ${theme.colors.primaryDark};
+        }
+        &:disabled {
+          background: ${theme.colors.textMuted};
+        }
+      `;
+    case 'outline':
+      return css`
+        background: ${theme.colors.surface};
+        color: ${theme.colors.text};
+        border: 1px solid ${theme.colors.border};
+        &:hover:not(:disabled) {
+          background: ${theme.colors.bg};
+        }
+      `;
+    case 'ghost':
+      return css`
+        background: transparent;
+        color: ${theme.colors.primary};
+        padding: 0;
+        &:hover:not(:disabled) {
+          color: ${theme.colors.primaryDark};
+        }
+      `;
+    case 'dashed':
+      return css`
+        background: ${theme.colors.primarySoft};
+        color: ${theme.colors.primary};
+        border: 1px dashed ${theme.colors.primary};
+        &:hover:not(:disabled) {
+          background: ${theme.colors.primaryLight};
+        }
+      `;
+  }
+}
+
+function getSizeStyle($size: Size, $isIconOnly: boolean) {
+  if ($isIconOnly) {
+    const dimension = ICON_ONLY_SIZE[$size];
+    return css`
+      width: ${dimension};
+      height: ${dimension};
+      padding: 0;
+      flex-shrink: 0;
+    `;
+  }
+
+  switch ($size) {
+    case 'sm':
+      return css`
+        padding: 6px 10px;
+        font-size: 12px;
+        border-radius: 8px;
+        gap: 4px;
+      `;
+    case 'md':
+      return css`
+        padding: 8px 12px;
+        font-size: 12px;
+        border-radius: 10px;
+        gap: 6px;
+      `;
+    case 'lg':
+      return css`
+        padding: 14px 20px;
+        font-size: 15px;
+        border-radius: 12px;
+        gap: 6px;
+      `;
+  }
+}
+
+const StyledButton = styled.button<{
+  $variant: Variant;
+  $size: Size;
+  $isIconOnly: boolean;
+  $width?: CSSProperties['width'];
+}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  transition:
+    background 0.15s,
+    color 0.15s;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  ${({ $variant, theme }) => getVariantStyle($variant, theme)}
+  ${({ $size, $isIconOnly }) => getSizeStyle($size, $isIconOnly)}
+  ${({ $width }) =>
+    $width &&
+    css`
+      width: ${$width};
+    `}
+`;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -9,12 +9,6 @@ const ICON_ONLY_SIZE: Record<Size, string> = {
   lg: '40px',
 };
 
-const BORDER_RADIUS: Record<Size, string> = {
-  sm: '8px',
-  md: '10px',
-  lg: '12px',
-};
-
 const ICON_SIZE: Record<Size, string> = {
   sm: '14px',
   md: '16px',
@@ -120,15 +114,20 @@ function getVariantStyle($variant: Variant, $tone: GhostTone, theme: Theme) {
   }
 }
 
-function getSizeStyle($size: Size, $isIconOnly: boolean) {
+function getSizeStyle($size: Size, $isIconOnly: boolean, theme: Theme) {
   if ($isIconOnly) {
     const dimension = ICON_ONLY_SIZE[$size];
+    const radiusMap: Record<Size, string> = {
+      sm: theme.radius.sm,
+      md: theme.radius.sm,
+      lg: theme.radius.md,
+    };
     return css`
       width: ${dimension};
       height: ${dimension};
       padding: 0;
       flex-shrink: 0;
-      border-radius: ${BORDER_RADIUS[$size]};
+      border-radius: ${radiusMap[$size]};
       svg {
         width: ${ICON_SIZE[$size]};
         height: ${ICON_SIZE[$size]};
@@ -141,7 +140,7 @@ function getSizeStyle($size: Size, $isIconOnly: boolean) {
       return css`
         padding: 6px 10px;
         font-size: 12px;
-        border-radius: ${BORDER_RADIUS.sm};
+        border-radius: ${theme.radius.sm};
         gap: 4px;
         svg {
           width: ${ICON_SIZE.sm};
@@ -152,7 +151,7 @@ function getSizeStyle($size: Size, $isIconOnly: boolean) {
       return css`
         padding: 8px 12px;
         font-size: 12px;
-        border-radius: ${BORDER_RADIUS.md};
+        border-radius: ${theme.radius.sm};
         gap: 6px;
         svg {
           width: ${ICON_SIZE.md};
@@ -163,7 +162,7 @@ function getSizeStyle($size: Size, $isIconOnly: boolean) {
       return css`
         padding: 14px 20px;
         font-size: 15px;
-        border-radius: ${BORDER_RADIUS.lg};
+        border-radius: ${theme.radius.md};
         gap: 6px;
         svg {
           width: ${ICON_SIZE.lg};
@@ -194,7 +193,7 @@ const StyledButton = styled.button<{
   }
 
   ${({ $variant, $tone, theme }) => getVariantStyle($variant, $tone, theme)}
-  ${({ $size, $isIconOnly }) => getSizeStyle($size, $isIconOnly)}
+  ${({ $size, $isIconOnly, theme }) => getSizeStyle($size, $isIconOnly, theme)}
   ${({ $width }) =>
     $width &&
     css`

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -30,9 +30,9 @@ export const theme = {
 
   radius: {
     sm: '8px',
-    md: '12px',
-    lg: '16px',
-    xl: '20px',
+    md: '10px',
+    lg: '12px',
+    xl: '14px',
     full: '999px',
   },
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #23

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h 30m

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- `src/components/common/Button.tsx` 공통 Button 컴포넌트 구현
- variant(primary / outline / ghost / dashed) 4종, size(sm / md / lg) 3종 지원
- `iconStart` / `iconEnd` prop으로 아이콘을 앞/뒤에 독립 배치
- children 없이 아이콘만 넘기면 정사각형 아이콘 전용 버튼으로 자동 전환
- `width` prop으로 버튼 너비 자유롭게 지정
- ghost variant 전용 `tone` prop(blue / black / red)으로 색상 선택 가능
- lucide-react 기준 size별 아이콘 크기 CSS로 자동 제어
- 모바일 탭 인터랙션을 위해 `:active` 스타일 적용

### 사용 방법 및 props
| prop | 타입 | 기본값 | 설명 |
|---|---|---|---|
| `type ` | `button \| submit \| reset` | `button` | 버튼 타입 |
| `variant` | `primary \| outline \| ghost \| dashed` | `primary` | 버튼 스타일 |
| `size` | `sm \| md \| lg` | `md` | 버튼 크기 |
| `tone` | `blue \| black \| red` | `blue` | ghost 색상 (ghost일 때만 유효) |
| `iconStart` | `ReactNode` | - | 텍스트 앞 아이콘 |
| `iconEnd` | `ReactNode` | - | 텍스트 뒤 아이콘 |
| `width` | `CSSProperties['width']` | - | 버튼 너비 |

이외 `onClick`, `disabled`, `aria-label` 등 HTML button 속성 전부 사용 가능합니다.

```tsx
<Button variant="primary" size="lg" width="100%">분석 시작</Button>
<Button variant="outline" size="md" iconStart={<Plus />}>추가</Button>
<Button variant="ghost" tone="red" iconEnd={<Trash />}>삭제</Button>

// 아이콘 전용 버튼
<Button variant="outline" size="md" iconStart={<Search />} aria-label="검색" />
```

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="726" height="709" alt="1" src="https://github.com/user-attachments/assets/fddd862f-44fb-461a-9d87-32fdb8fdf728" />
<img width="726" height="645" alt="2" src="https://github.com/user-attachments/assets/f12c6e67-8472-45e9-956c-7eb7b0f17435" />
<img width="726" height="482" alt="3" src="https://github.com/user-attachments/assets/3c028a03-90fd-4c88-b3c8-fabca973098d" />
<img width="726" height="714" alt="4" src="https://github.com/user-attachments/assets/a74afaa8-e2d7-4bc9-8ab8-be4299b8f19a" />


<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### lucide-react 아이콘 크기 제어 방식
size별로 아이콘 크기를 맞춰야 했는데, 선택지가 세 가지였습니다.

1. 아이콘을 넘길 때 직접 size prop 지정
2. cloneElement로 Button 내부에서 아이콘에 size 주입
3. CSS svg { width/height }로 제어

1번은 사용할 때마다 크기를 신경 써야 해서 번거롭고, 
2번은 React 공식 문서에서 권장하지 않는 방식입니다. 
lucide-react가 SVG로 렌더되어 CSS로 크기 제어가 가능해서 3번을 선택했습니다. 
사용하는 쪽에서 아무것도 신경 쓰지 않아도 됩니다.

### 커스텀 props DOM 전달 차단
Button 컴포넌트는 스타일 계산을 위해 `variant`, `size` 같은 props를 내부적으로 사용합니다.
이 값들이 최종적으로 렌더되는 `<button>` HTML 태그까지 그대로 흘러내려가면,
브라우저 입장에서 `<button variant="primary" size="lg">`처럼 존재하지 않는 HTML 속성을 받게 되어 콘솔에 경고가 발생합니다.

이를 막기 위해 Emotion 권장 방식인 `$` prefix를 사용했습니다.
prop 이름 앞에 `$`를 붙이면 Emotion이 CSS 계산에만 사용하고 HTML 태그로는 전달하지 않습니다.

```tsx
// Button 내부에서 $ 붙여서 전달
<StyledButton $variant={variant} $size={size} ...>

// Emotion이 $variant를 읽어 CSS 생성 후 class로 변환
// 최종 렌더 결과 — $variant, $size는 사라지고 class만 남음
<button class="css-1a2b3c">분석 시작</button>
```

### 모바일 탭 인터랙션
서비스 주 타깃이 모바일인데, 모바일에서는 :hover가 동작하지 않아 버튼을 눌러도 아무런 피드백이 없는 문제가 있었습니다. 
모든 variant의 hover 선택자에 :active:not(:disabled)를 병기해서, 탭하고 있는 동안 동일한 스타일이 발동하도록 처리했습니다.

### ghost variant 색상 확장
ghost 버튼은 사용되는 맥락에 따라 파란색(기본 액션), 검정색(보조 액션), 빨간색(삭제/위험) 등 색상이 달라져야 했습니다. 
variant를 늘리면 조합이 너무 많아져서, ghost 전용 tone prop을 추가했습니다. 
GHOST_TONE 맵에 { color, hoverBg } 쌍을 관리해서, 
나중에 색상을 추가할 때 맵과 타입 두 곳만 수정하면 되는 구조로 만들었습니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- ghost 외 variant에도 tone prop이 노출되는 구조인데, ghost 전용임을 타입 레벨에서 강제할지 여부
- GHOST_TONE 맵을 함수 내부에 선언한 것 (theme 참조가 필요해서 모듈 최상단에 뺄 수 없음)

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 새로운 버튼 컴포넌트가 추가되었습니다. 기본/아웃라인/고스트/대시의 4가지 시각 변형과 sm/md/lg의 3가지 크기를 제공하며, 시작/끝 아이콘 삽입과 아이콘 전용 모드, 테마 기반 색상·호버·비활성화 처리를 지원합니다.

* **스타일**
  * 디자인 토큰의 코너 반경이 조정되어 중간/대형/특대 크기에서 모서리 반경이 소폭 감소했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->