### PR TITLE
[feat] 공통 Input 컴포넌트 구현 (#24)

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import type { CSSProperties, InputHTMLAttributes, ReactNode } from 'react';
-import { theme } from '../../styles/theme';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   start?: ReactNode;
@@ -64,7 +63,7 @@ const Slot = styled.span<{
   position: absolute;
   display: flex;
   align-items: center;
-  color: ${theme.colors.textMuted};
+  color: ${({ theme }) => theme.colors.textMuted};
   font-size: 14px;
   font-weight: 500;
   pointer-events: ${({ $interactive, $disabled }) =>
@@ -75,8 +74,8 @@ const Slot = styled.span<{
 
 const StyledInput = styled.input<{ $hasStart: boolean; $hasEnd: boolean }>`
   width: 100%;
-  background: ${theme.colors.bg};
-  border-radius: ${theme.radius.md};
+  background: ${({ theme }) => theme.colors.bg};
+  border-radius: ${({ theme }) => theme.radius.md};
   font-size: 14px;
   outline: none;
   transition:
@@ -87,12 +86,12 @@ const StyledInput = styled.input<{ $hasStart: boolean; $hasEnd: boolean }>`
     ${({ $hasStart }) => ($hasStart ? '40px' : '14px')};
 
   &:focus {
-    border-color: ${theme.colors.primary};
-    background: ${theme.colors.surface};
+    border-color: ${({ theme }) => theme.colors.primary};
+    background: ${({ theme }) => theme.colors.surface};
   }
 
   &::placeholder {
-    color: ${theme.colors.textMuted};
+    color: ${({ theme }) => theme.colors.textMuted};
   }
 
   &:disabled {

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled';
+import type { CSSProperties, InputHTMLAttributes, ReactNode } from 'react';
+import { theme } from '../../styles/theme';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  start?: ReactNode;
+  end?: ReactNode;
+  startInteractive?: boolean;
+  endInteractive?: boolean;
+  width?: CSSProperties['width'];
+}
+
+export function Input({
+  start,
+  end,
+  startInteractive = false,
+  endInteractive = false,
+  width,
+  ...rest
+}: InputProps) {
+  return (
+    <Wrapper $width={width}>
+      {start && (
+        <Slot $position="start" $interactive={startInteractive}>
+          {start}
+        </Slot>
+      )}
+      <StyledInput $hasStart={!!start} $hasEnd={!!end} {...rest} />
+      {end && (
+        <Slot $position="end" $interactive={endInteractive}>
+          {end}
+        </Slot>
+      )}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div<{ $width?: CSSProperties['width'] }>`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: ${({ $width }) => $width ?? '100%'};
+`;
+
+const Slot = styled.span<{ $position: 'start' | 'end'; $interactive: boolean }>`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  color: ${theme.colors.textMuted};
+  font-size: 14px;
+  font-weight: 500;
+  pointer-events: ${({ $interactive }) => ($interactive ? 'auto' : 'none')};
+  ${({ $position }) => ($position === 'start' ? 'left: 14px;' : 'right: 14px;')}
+`;
+
+const StyledInput = styled.input<{ $hasStart: boolean; $hasEnd: boolean }>`
+  width: 100%;
+  background: ${theme.colors.bg};
+  border-radius: ${theme.radius.md};
+  font-size: 14px;
+  outline: none;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+
+  padding: 14px ${({ $hasEnd }) => ($hasEnd ? '40px' : '14px')} 14px
+    ${({ $hasStart }) => ($hasStart ? '40px' : '14px')};
+
+  &:focus {
+    border-color: ${theme.colors.primary};
+    background: ${theme.colors.surface};
+  }
+
+  &::placeholder {
+    color: ${theme.colors.textMuted};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -16,18 +16,32 @@ export function Input({
   startInteractive = false,
   endInteractive = false,
   width,
+  disabled,
   ...rest
 }: InputProps) {
   return (
     <Wrapper $width={width}>
       {start && (
-        <Slot $position="start" $interactive={startInteractive}>
+        <Slot
+          $position="start"
+          $interactive={startInteractive}
+          $disabled={!!disabled}
+        >
           {start}
         </Slot>
       )}
-      <StyledInput $hasStart={!!start} $hasEnd={!!end} {...rest} />
+      <StyledInput
+        $hasStart={!!start}
+        $hasEnd={!!end}
+        disabled={disabled}
+        {...rest}
+      />
       {end && (
-        <Slot $position="end" $interactive={endInteractive}>
+        <Slot
+          $position="end"
+          $interactive={endInteractive}
+          $disabled={!!disabled}
+        >
           {end}
         </Slot>
       )}
@@ -42,14 +56,20 @@ const Wrapper = styled.div<{ $width?: CSSProperties['width'] }>`
   width: ${({ $width }) => $width ?? '100%'};
 `;
 
-const Slot = styled.span<{ $position: 'start' | 'end'; $interactive: boolean }>`
+const Slot = styled.span<{
+  $position: 'start' | 'end';
+  $interactive: boolean;
+  $disabled: boolean;
+}>`
   position: absolute;
   display: flex;
   align-items: center;
   color: ${theme.colors.textMuted};
   font-size: 14px;
   font-weight: 500;
-  pointer-events: ${({ $interactive }) => ($interactive ? 'auto' : 'none')};
+  pointer-events: ${({ $interactive, $disabled }) =>
+    $disabled ? 'none' : $interactive ? 'auto' : 'none'};
+  opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
   ${({ $position }) => ($position === 'start' ? 'left: 14px;' : 'right: 14px;')}
 `;
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #24

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h 30m

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- `src/components/common/Input.tsx` 공통 Input 컴포넌트 구현
- `start` / `end` prop으로 아이콘, prefix 텍스트(₩), suffix 텍스트(원), 버튼 등 자유롭게 배치
- `start` / `end` 유무에 따라 input의 padding 자동 조정
- `startInteractive` / `endInteractive` prop으로 슬롯 클릭 이벤트 제어
- 포커스 시 border-color, background 전환 스타일 적용
- `width` prop으로 너비 자유롭게 지정

### 사용 방법 및 Props

| prop | 타입 | 기본값 | 설명 |
|---|---|---|---|
| `start` | `ReactNode` | - | 왼쪽 슬롯 (아이콘, 텍스트, 버튼) |
| `end` | `ReactNode` | - | 오른쪽 슬롯 (아이콘, 텍스트, 버튼) |
| `startInteractive` | `boolean` | `false` | start 슬롯 클릭 이벤트 허용 |
| `endInteractive` | `boolean` | `false` | end 슬롯 클릭 이벤트 허용 |
| `width` | `CSSProperties['width']` | `100%` | 인풋 너비 |

이외 `placeholder`, `disabled`, `onChange` 등 HTML input 속성 전부 사용 가능합니다.

```tsx
// 기본
<Input placeholder="주소를 입력하세요" />

// 왼쪽 아이콘
<Input start={<SearchIcon />} placeholder="주소를 입력하세요" />

// prefix / suffix 텍스트
<Input start="₩" end="원" placeholder="350,000,000" />

// 오른쪽 버튼 (클릭 가능)
<Input
  end={<button onClick={handleClear}>✕</button>}
  endInteractive
  placeholder="입력하세요"
/>

// 너비 지정
<Input start={<SearchIcon />} placeholder="검색" width="300px" />
```

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="960" height="1045" alt="input 시연 영상" src="https://github.com/user-attachments/assets/10d9c7b1-0118-4a2c-b760-c53d3c25e111" />
<img width="380" height="802" alt="input 종류 사진" src="https://github.com/user-attachments/assets/b44dc352-40bb-445c-8990-351d37c07e99" />

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### 슬롯에 버튼이 올 때 클릭 이벤트 처리
`Slot`에 `pointer-events: none`이 기본으로 걸려 있어서 아이콘/텍스트가 input 클릭을 막지 않습니다.
그런데 버튼이 들어올 경우 클릭이 막히는 문제가 있었습니다.

ReactNode가 버튼인지 자동 감지하는 방법도 검토했지만,
`isValidElement`로 타입을 확인하고 `cloneElement`로 props를 주입하는 방식은
React 공식 문서에서 권장하지 않는 방식입니다.
대신 `startInteractive` / `endInteractive` boolean prop을 추가해서
사용하는 쪽에서 명시적으로 클릭 허용 여부를 선언하도록 했습니다.

```tsx
// 슬롯이 아이콘/텍스트일 때 — pointer-events: none (기본)
<Input start={<SearchIcon />} placeholder="검색" />

// 슬롯이 버튼일 때 — endInteractive로 pointer-events: auto
<Input end={<button onClick={handleClear}>✕</button>} endInteractive />
```

### theme import 방식
Button 컴포넌트는 스타일 함수(`getVariantStyle`)에서 `theme: Theme` 파라미터를 직접 받아서
`import type { Theme } from '@emotion/react'`로 emotion.d.ts의 module augmentation을 트리거했습니다.
Input은 외부 스타일 함수가 없어서 대신 `import { theme } from '../../styles/theme'`으로
theme 상수를 직접 참조하는 방식을 택했습니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- startInteractive / endInteractive 네이밍이 직관적인지 여부
- start / end padding 값(40px)이 다양한 슬롯 콘텐츠 크기에 충분한지 여부

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.

[Emotion $ prefix transient props](https://emotion.sh/docs/styled#transient-props)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 재사용 가능한 Input 컴포넌트 추가: 표준 입력 속성을 지원하며 좌/우에 선택적 콘텐츠(start/end)를 배치할 수 있고 상호작용 가능 여부를 제어할 수 있습니다. 입력 너비 지정, 비활성 상태 처리(투명도 및 비활성화), 테마 기반 스타일링, 포커스 트랜지션 및 콘텐츠 존재에 따른 동적 패딩 조정이 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->