### PR TITLE
[refactor] layout 구조 개선 및 header를 props로 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { House } from 'lucide-react';
 import { Button } from './components/common/Button';
 import { Header } from './components/common/Header';
 import { Layout } from './layout/Layout';
+import { StepIndicator } from './components/common/StepIndicator';
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
           }
         />
       }
+      stepIndicator={<StepIndicator currentStep={1} totalSteps={4} />}
     >
       <div>레이아웃 테스트</div>
     </Layout>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,22 +5,24 @@ import { Layout } from './layout/Layout';
 
 function App() {
   return (
-    <Layout>
-      <Header
-        title="지켜줘홈즈"
-        left={
-          <Button
-            variant="ghost"
-            tone="blue"
-            size="sm"
-            iconStart={<House />}
-            aria-label="홈"
-          />
-        }
-      />
+    <Layout
+      header={
+        <Header
+          title="지켜줘홈즈"
+          left={
+            <Button
+              variant="ghost"
+              tone="blue"
+              size="sm"
+              iconStart={<House />}
+              aria-label="홈"
+            />
+          }
+        />
+      }
+    >
       <div>레이아웃 테스트</div>
     </Layout>
   );
 }
-
 export default App;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,14 +1,17 @@
 import styled from '@emotion/styled';
-import type { ReactNode } from 'react';
 
 interface LayoutProps {
-  children: ReactNode;
+  header?: React.ReactNode;
+  children: React.ReactNode;
 }
 
-export function Layout({ children }: LayoutProps) {
+export function Layout({ header, children }: LayoutProps) {
   return (
     <Wrapper>
-      <LayoutWrapper>{children}</LayoutWrapper>
+      <LayoutWrapper>
+        {header}
+        <PageContent>{children}</PageContent>
+      </LayoutWrapper>
     </Wrapper>
   );
 }
@@ -29,4 +32,9 @@ const LayoutWrapper = styled.main`
   flex-direction: column;
   overflow-x: hidden;
   background-color: ${({ theme }) => theme.colors.surface};
+`;
+
+const PageContent = styled.section`
+  flex: 1;
+  padding: 16px 20px 24px;
 `;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,16 +1,28 @@
 import styled from '@emotion/styled';
 
+type ContentBackground = 'surface' | 'bg';
+
 interface LayoutProps {
   header?: React.ReactNode;
+  stepIndicator?: React.ReactNode;
+  contentBackground?: ContentBackground;
   children: React.ReactNode;
 }
 
-export function Layout({ header, children }: LayoutProps) {
+export function Layout({
+  header,
+  stepIndicator,
+  contentBackground = 'bg',
+  children,
+}: LayoutProps) {
   return (
     <Wrapper>
       <LayoutWrapper>
         {header}
-        <PageContent>{children}</PageContent>
+        {stepIndicator}
+        <PageContent $contentBackground={contentBackground}>
+          {children}
+        </PageContent>
       </LayoutWrapper>
     </Wrapper>
   );
@@ -20,6 +32,7 @@ const Wrapper = styled.div`
   min-height: 100dvh;
   display: flex;
   justify-content: center;
+  background-color: ${({ theme }) => theme.colors.border};
 `;
 
 const LayoutWrapper = styled.main`
@@ -34,7 +47,9 @@ const LayoutWrapper = styled.main`
   background-color: ${({ theme }) => theme.colors.surface};
 `;
 
-const PageContent = styled.section`
+const PageContent = styled.div<{ $contentBackground: ContentBackground }>`
   flex: 1;
-  padding: 16px 20px 24px;
+  padding: 24px 20px;
+  background-color: ${({ theme, $contentBackground }) =>
+    theme.colors[$contentBackground]};
 `;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
+import type { ReactNode } from 'react';
 
 type ContentBackground = 'surface' | 'bg';
 
 interface LayoutProps {
-  header?: React.ReactNode;
-  stepIndicator?: React.ReactNode;
+  header?: ReactNode;
+  stepIndicator?: ReactNode;
   contentBackground?: ContentBackground;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function Layout({


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #이슈번호

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- Layout 컴포넌트 구조 개선
- Header를 Layout 내부에서 직접 사용하지 않고 props로 전달하도록 변경
- StepIndicator를 Layout에서 직접 사용하지 않고 props로 전달하도록 변경
- 본문 영역에만 padding이 적용되도록 PageContent 분리
- PageContent에 배경 옵션을 추가하여 페이지별 배경색 분기 처리
  - 일반 페이지: `theme.colors.bg`
  - 랜딩 페이지: `theme.colors.surface`
- Header / StepIndicator / 본문 영역의 역할을 명확히 분리하여 재사용성과 확장성 개선
- Header와 본문 영역의 역할을 명확히 분리하여 재사용성과 확장성 개선

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="311" height="191" alt="image" src="https://github.com/user-attachments/assets/dfb37b0a-0a50-499d-9381-46f5558a135f" />

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- [트러블 슈팅1](링크)


1. Header를 Layout 내부에 둘지, 외부에서 주입할지
Layout 내부에 Header를 직접 import하면 구현은 단순하지만,
페이지별로 Header의 title, 버튼 구성이 달라질 경우 확장성이 떨어진다고 판단

👊🏻 해결:
Header를 props로 받아 Layout은 "배치만 담당"하도록 역할 분리

2. padding 적용 위치
Layout에 padding을 주면 Header까지 영향을 받는 문제 발생

👊🏻 해결:
본문 영역만 감싸는 PageContent를 분리하여 padding 적용

```
Layout
 ├─ Header        (padding 없음)
 └─ PageContent   (padding 적용)
```

3. 페이지별 배경색 분기

일반 페이지는 StepIndicator 아래 본문 영역이 회색 배경이어야 하지만, 랜딩 페이지는 전체 흰 배경이 필요했다.

👊🏻 해결:
contentBackground props를 추가해 PageContent 배경색을 페이지별로 선택할 수 있도록 처리

4. StepIndicator 적용 위치

StepIndicator도 페이지마다 현재 단계가 달라지는 컴포넌트이므로 Layout 내부에서 직접 관리하면 페이지별 상태 대응이 어려워진다고 판단했다.

👊🏻 해결:  
StepIndicator도 props로 전달받도록 하여, 각 페이지에서 `currentStep`을 결정할 수 있도록 구성
<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고

랜딩페이지를 제외한 정보입력페이지, 분석중페이지, 결과페이지를 기준으로 레이아웃이 우선 구현되었습니다.

랜딩페이지는 구조나 스타일 성격이 다른 편이라, 추후에는 동일한 Layout을 적용하기보다는 별도의 Layout을 분리하거나 예외 처리하는 방향으로 가져가야 할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* 레이아웃 컴포넌트의 구조를 재정렬했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->