### PR TITLE
[feat] 홈 서비스 소개 섹션 구현 (#37)

### DIFF
--- a/src/components/feature/LandingPage/FeatureSection/FeatureCard.tsx
+++ b/src/components/feature/LandingPage/FeatureSection/FeatureCard.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+import type { LucideIcon } from 'lucide-react';
+import { Card } from '../../../common/Card';
+
+const ICON_SIZE = 52;
+const ICON_STROKE_WIDTH = 1.5;
+
+interface FeatureCardProps {
+  Icon: LucideIcon;
+  title: string;
+  desc: string;
+}
+
+export function FeatureCard({ Icon, title, desc }: FeatureCardProps) {
+  return (
+    <StyledCard>
+      <IconWrap>
+        <Icon
+          size={ICON_SIZE}
+          strokeWidth={ICON_STROKE_WIDTH}
+          aria-hidden="true"
+        />
+      </IconWrap>
+      <CardTitle>{title}</CardTitle>
+      <CardDesc>{desc}</CardDesc>
+    </StyledCard>
+  );
+}
+
+const StyledCard = styled(Card)`
+  align-items: center;
+  text-align: center;
+  padding: 20px 14px;
+
+  &:last-child:nth-of-type(odd) {
+    grid-column: span 2;
+  }
+`;
+
+const IconWrap = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 4px;
+  color: ${({ theme }) => theme.colors.primary};
+`;
+
+const CardTitle = styled.h3`
+  margin: 0 0 2px;
+  font-size: 14px;
+  font-weight: 800;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const CardDesc = styled.p`
+  margin: 0;
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.textMuted};
+  line-height: 1.5;
+  white-space: pre-line;
+`;

--- a/src/components/feature/LandingPage/FeatureSection/FeatureGrid.tsx
+++ b/src/components/feature/LandingPage/FeatureSection/FeatureGrid.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+import { FeatureCard } from './FeatureCard';
+import { FEATURE_ITEMS } from '../../../../constants/featureItems';
+
+export function FeatureGrid() {
+  return (
+    <Grid>
+      {FEATURE_ITEMS.map((item) => (
+        <FeatureCard
+          key={item.title}
+          Icon={item.Icon}
+          title={item.title}
+          desc={item.desc}
+        />
+      ))}
+    </Grid>
+  );
+}
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+`;

--- a/src/components/feature/LandingPage/FeatureSection/FeatureSection.tsx
+++ b/src/components/feature/LandingPage/FeatureSection/FeatureSection.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { FeatureSectionHeader } from './FeatureSectionHeader';
+import { FeatureGrid } from './FeatureGrid';
+
+export function FeatureSection() {
+  return (
+    <Section>
+      <Inner>
+        <FeatureSectionHeader />
+        <FeatureGrid />
+      </Inner>
+    </Section>
+  );
+}
+
+const Section = styled.section`
+  width: 100%;
+  max-width: 420px;
+  padding: 32px 0 0;
+`;
+
+const Inner = styled.div`
+  background: ${({ theme }) => theme.colors.primarySoft};
+  border-radius: 22px;
+  padding: 28px 18px;
+`;

--- a/src/components/feature/LandingPage/FeatureSection/FeatureSectionHeader.tsx
+++ b/src/components/feature/LandingPage/FeatureSection/FeatureSectionHeader.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+export function FeatureSectionHeader() {
+  return (
+    <>
+      <Eyebrow>지켜줘 홈즈가 도와드리는 것</Eyebrow>
+      <Heading>
+        계약 전, 꼭 확인해야 할
+        <br />
+        정보들을 한 번에!
+      </Heading>
+    </>
+  );
+}
+
+const Eyebrow = styled.p`
+  margin: 0 0 8px;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.primary};
+  font-size: 12px;
+  font-weight: 800;
+`;
+
+const Heading = styled.h2`
+  margin: 0 0 24px;
+  text-align: center;
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  color: ${({ theme }) => theme.colors.text};
+  line-height: 1.4;
+`;

--- a/src/components/feature/LandingPage/HeroSection.tsx
+++ b/src/components/feature/LandingPage/HeroSection.tsx
@@ -20,7 +20,6 @@ export function HeroSection() {
 }
 
 const Section = styled.section`
-  background: linear-gradient(180deg, #ffffff 0%, #f5f7fb 100%);
   text-align: center;
   width: 100%;
   max-width: 420px;

--- a/src/constants/featureItems.ts
+++ b/src/constants/featureItems.ts
@@ -1,0 +1,42 @@
+import {
+  FileSearchCorner,
+  Building2,
+  ChartNoAxesCombined,
+  ListChecks,
+  ShieldAlert,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+interface FeatureItem {
+  title: string;
+  desc: string;
+  Icon: LucideIcon;
+}
+
+export const FEATURE_ITEMS: FeatureItem[] = [
+  {
+    title: '등기부등본 분석',
+    desc: '권리 관계를\n꼼꼼히 분석해요.',
+    Icon: FileSearchCorner,
+  },
+  {
+    title: '건축물 정보',
+    desc: '위반 여부와 용도를\n확인해요.',
+    Icon: Building2,
+  },
+  {
+    title: '전세가율 체크',
+    desc: '매매가 대비\n위험도를 평가해요.',
+    Icon: ChartNoAxesCombined,
+  },
+  {
+    title: '체크리스트',
+    desc: '꼭 확인할 항목을\n정리해드려요.',
+    Icon: ListChecks,
+  },
+  {
+    title: '위험도 진단',
+    desc: 'AI가 종합 판단해\n주의사항을 알려드려요.',
+    Icon: ShieldAlert,
+  },
+];

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 import { HeroSection } from '../../components/feature/LandingPage/HeroSection';
+import { FeatureSection } from '../../components/feature/LandingPage/FeatureSection/FeatureSection';
 
 export function LandingPage() {
   return (
     <PageWrapper>
       <HeroSection />
+      <FeatureSection />
     </PageWrapper>
   );
 }
@@ -12,4 +14,8 @@ export function LandingPage() {
 const PageWrapper = styled.main`
   padding: 32px 20px 36px;
   background: linear-gradient(180deg, #ffffff 0%, #f5f7fb 100%);
+
+  & > *:not(:last-child) {
+    margin-bottom: 24px;
+  }
 `;


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #37 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- FeatureSectionHeader.tsx
  - eyebrow 문구 + h2 타이틀 렌더링
- FeatureCard.tsx
  - 아이콘, 제목, 설명을 담는 카드 컴포넌트
  - common/Card를 styled()로 확장하여 재사용
- FeatureGrid.tsx
  - 2×2 카드 그리드 레이아웃, 홀수 마지막 카드 full-width 처리
- FeatureSection.tsx
  - 위 컴포넌트 조합 및 Inner 배경(primarySoft) 적용
- constants/featureItems.ts
  - FEATURE_ITEMS 상수 분리, LucideIcon 참조 구조
  - 아이콘 색상을 color prop 대신 IconWrap CSS color + currentColor로 주입해 모드 변환 대응
- LandingPage.tsx
  - FeatureSection 추가
  - HeroSection 중복 background 제거, PageWrapper로 gradient 책임 통합
  - 섹션 간 margin-bottom 24px 적용 (마지막 자식 제외)

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="420" height="751" alt="홈서비스소개섹션" src="https://github.com/user-attachments/assets/d8197957-ab4a-4190-af8f-b12242c11618" />

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### featureItems 데이터 구조
처음에는 icon 필드에 `<FileSearchCorner size={52} color="#3B82F6" />` 형태의 JSX를 직접 담았습니다.
그런데 constants 폴더에 JSX가 섞이면 순수 데이터 역할과 맞지 않고, 파일 확장자도 `.tsx`가 되어야 해서 어색했습니다.
그래서 icon 대신 `Icon: LucideIcon` 형태로 컴포넌트 참조만 담고, 실제 렌더링(size, strokeWidth)은 FeatureCard에서 담당하도록 분리했습니다. 덕분에 featureItems는 `.ts`로 관리할 수 있게 됐습니다.

### 아이콘 색상 다크모드 대응
처음에는 아이콘에 `color={theme.colors.primary}`를 직접 prop으로 넘겼습니다.
그런데 이 방식은 모듈 로드 시점에 색상값이 문자열로 고정되어, 나중에 다크모드로 ThemeProvider가 전환되어도 아이콘 색상이 바뀌지 않는 문제가 있었습니다.
그래서 아이콘의 color prop을 제거하고, 부모인 IconWrap에 `color: ${({ theme }) => theme.colors.primary}`를 주입했습니다. lucide 아이콘은 기본적으로 `currentColor`를 따라가기 때문에, ThemeProvider가 theme을 바꾸면 아이콘 색상도 자동으로 함께 바뀝니다.

### 섹션별 배경 끊김 문제
HeroSection 내부에도 `background: linear-gradient(...)`가 선언되어 있어서, PageWrapper의 gradient와 별개로 각 섹션마다 독립적으로 적용되고 있었습니다. 그 결과 섹션이 바뀌는 경계에서 배경이 끊겨 보이는 현상이 있었습니다.
HeroSection의 background 선언을 제거하고 PageWrapper 하나에서만 gradient를 관리하도록 통합해, 페이지 전체에 걸쳐 배경이 자연스럽게 이어지도록 수정했습니다.


<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- FeatureCard에서 common/Card를 styled()로 확장한 방식이 적절한지

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.
