### PR TITLE
[feat] 홈 사용 방법 섹션 구현 (#38)

### DIFF
--- a/src/components/feature/LandingPage/StepSection/StepArrow.tsx
+++ b/src/components/feature/LandingPage/StepSection/StepArrow.tsx
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+import { ChevronDown } from 'lucide-react';
+
+export function StepArrow() {
+  return (
+    <ArrowWrap>
+      <ChevronDown />
+    </ArrowWrap>
+  );
+}
+
+const ArrowWrap = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.primary};
+`;

--- a/src/components/feature/LandingPage/StepSection/StepCard.tsx
+++ b/src/components/feature/LandingPage/StepSection/StepCard.tsx
@@ -1,0 +1,93 @@
+import styled from '@emotion/styled';
+import { Circle } from 'lucide-react';
+import { Card } from '../../../common/Card';
+import { Tag } from '../../../common/Tag';
+import type { StepItem } from '../../../../constants/stepItems';
+
+const ICON_SIZE = 44;
+const ICON_STROKE_WIDTH = 1.5;
+
+type StepCardProps = StepItem;
+
+export function StepCard({ step, title, desc, hint, Icon }: StepCardProps) {
+  return (
+    <StyledCard>
+      <NumBadge>{step}</NumBadge>
+      <Body>
+        <Title>{title}</Title>
+        <Desc>{desc}</Desc>
+        <HintTag variant="primary">
+          <Circle fill="currentColor" />
+          {hint}
+        </HintTag>
+      </Body>
+      <IconWrap>
+        <Icon
+          size={ICON_SIZE}
+          strokeWidth={ICON_STROKE_WIDTH}
+          aria-hidden="true"
+        />
+      </IconWrap>
+    </StyledCard>
+  );
+}
+
+const StyledCard = styled(Card)`
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 18px 16px;
+`;
+
+const NumBadge = styled.div`
+  width: 28px;
+  height: 28px;
+  border-radius: ${({ theme }) => theme.radius.full};
+  background: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colors.surface};
+  font-size: 13px;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const Body = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const Title = styled.h3`
+  margin-top: 2px;
+  margin-bottom: 4px;
+  font-size: 15px;
+  font-weight: 800;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Desc = styled.p`
+  margin-bottom: 10px;
+  font-size: 12.5px;
+  color: ${({ theme }) => theme.colors.textMuted};
+  line-height: 1.5;
+  white-space: pre-line;
+`;
+
+const HintTag = styled(Tag)`
+  font-weight: 800;
+  gap: 4px;
+
+  svg {
+    width: 8px;
+    height: 8px;
+  }
+`;
+
+const IconWrap = styled.div`
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.primary};
+`;

--- a/src/components/feature/LandingPage/StepSection/StepList.tsx
+++ b/src/components/feature/LandingPage/StepSection/StepList.tsx
@@ -1,0 +1,24 @@
+import { Fragment } from 'react';
+import styled from '@emotion/styled';
+import { STEP_ITEMS } from '../../../../constants/stepItems';
+import { StepCard } from './StepCard';
+import { StepArrow } from './StepArrow';
+
+export function StepList() {
+  return (
+    <Col>
+      {STEP_ITEMS.map((item, i) => (
+        <Fragment key={item.step}>
+          <StepCard {...item} />
+          {i < STEP_ITEMS.length - 1 && <StepArrow />}
+        </Fragment>
+      ))}
+    </Col>
+  );
+}
+
+const Col = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;

--- a/src/components/feature/LandingPage/StepSection/StepSection.tsx
+++ b/src/components/feature/LandingPage/StepSection/StepSection.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { StepSectionHeader } from './StepSectionHeader';
+import { StepList } from './StepList';
+
+export function StepSection() {
+  return (
+    <Section>
+      <Inner>
+        <StepSectionHeader />
+        <StepList />
+      </Inner>
+    </Section>
+  );
+}
+
+const Section = styled.section`
+  width: 100%;
+  max-width: 420px;
+  padding: 32px 0 0;
+`;
+
+const Inner = styled.div`
+  background: ${({ theme }) => theme.colors.primarySoft};
+  border-radius: 22px;
+  padding: 28px 18px;
+`;

--- a/src/components/feature/LandingPage/StepSection/StepSectionHeader.tsx
+++ b/src/components/feature/LandingPage/StepSection/StepSectionHeader.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+export function StepSectionHeader() {
+  return (
+    <>
+      <Eyebrow>사용 방법</Eyebrow>
+      <Heading>3단계로 쉽고 간단하게!</Heading>
+    </>
+  );
+}
+
+const Eyebrow = styled.p`
+  margin-bottom: 8px;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.primary};
+  font-size: 12px;
+  font-weight: 800;
+`;
+
+const Heading = styled.h2`
+  margin-bottom: 24px;
+  text-align: center;
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  color: ${({ theme }) => theme.colors.text};
+`;

--- a/src/constants/stepItems.ts
+++ b/src/constants/stepItems.ts
@@ -1,0 +1,34 @@
+import { TextCursorInput, LoaderCircle, ReceiptText } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface StepItem {
+  step: number;
+  title: string;
+  desc: string;
+  hint: string;
+  Icon: LucideIcon;
+}
+
+export const STEP_ITEMS: StepItem[] = [
+  {
+    step: 1,
+    title: '정보 입력',
+    desc: '계약 정보와 부동산 정보를 입력해요.',
+    hint: '계약서, 주소, 보증금',
+    Icon: TextCursorInput,
+  },
+  {
+    step: 2,
+    title: '분석 진행',
+    desc: 'AI가 공공데이터와 법적 정보를 분석해요.',
+    hint: '평균 1~2분',
+    Icon: LoaderCircle,
+  },
+  {
+    step: 3,
+    title: '결과 확인',
+    desc: '위험도와 상세 분석, 주의사항을 확인해요.',
+    hint: '리포트 다운로드 가능',
+    Icon: ReceiptText,
+  },
+];

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -1,6 +1,10 @@
-export type TagVariant = 'success' | 'warning' | 'danger';
+export type TagVariant = 'primary' | 'success' | 'warning' | 'danger';
 
 export const TAG_COLORS = {
+  primary: {
+    color: 'primaryDark',
+    background: 'primaryLight',
+  },
   success: {
     color: 'success',
     background: 'successBg',

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
 import { HeroSection } from '../../components/feature/LandingPage/HeroSection';
 import { FeatureSection } from '../../components/feature/LandingPage/FeatureSection/FeatureSection';
+import { StepSection } from '../../components/feature/LandingPage/StepSection/StepSection';
 
 export function LandingPage() {
   return (
     <PageWrapper>
       <HeroSection />
       <FeatureSection />
+      <StepSection />
     </PageWrapper>
   );
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #38 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- `src/components/feature/LandingPage/StepSection/` 하위에 StepSection 관련 컴포넌트 구현
- `constants/stepItems.ts`에 단계 데이터 상수 분리 (FeatureItems 패턴 동일)
- `constants/tag.ts`에 `primary` variant 추가
- `LandingPage`에 StepSection 추가

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="418" height="607" alt="StepSection" src="https://github.com/user-attachments/assets/b116e9be-3faf-4803-b980-feae04a75136" />

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### Hint 뱃지를 어떻게 구현할까
처음엔 별도 styled 컴포넌트로 만들었는데, 이미 Tag 공통 컴포넌트가 있어서 재사용하는 게 맞다고 판단했습니다.
그런데 Tag에는 primary 색상 variant가 없었고, props로 font-weight를 받게 확장하는 방법도 고민했습니다.
결국 Tag 자체는 건드리지 않고 `styled(Tag)`로 font-weight만 오버라이드하고, primary variant만 상수에 추가하는 방식으로 최소한의 변경으로 해결했습니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- `Tag`에 `primary` variant 추가한 방향이 괜찮은지

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.
