### PR TITLE
[feat] 홈 추천 대상 섹션 구현 (#39)

### DIFF
--- a/src/components/feature/LandingPage/TargetSection/TargetCard.tsx
+++ b/src/components/feature/LandingPage/TargetSection/TargetCard.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+import { Card } from '../../../common/Card';
+
+const AVATAR_SIZE = 88;
+
+interface TargetCardProps {
+  img: string;
+  title: string;
+  desc: string;
+}
+
+export function TargetCard({ img, title, desc }: TargetCardProps) {
+  return (
+    <StyledCard>
+      <Avatar
+        src={img}
+        alt={title}
+        width={AVATAR_SIZE}
+        height={AVATAR_SIZE}
+        loading="lazy"
+      />
+      <CardTitle>{title}</CardTitle>
+      <CardDesc>{desc}</CardDesc>
+    </StyledCard>
+  );
+}
+
+const StyledCard = styled(Card)`
+  align-items: center;
+  text-align: center;
+  padding: 20px 12px 18px;
+  gap: 6px;
+`;
+
+const Avatar = styled.img`
+  width: ${AVATAR_SIZE}px;
+  height: ${AVATAR_SIZE}px;
+  object-fit: contain;
+  margin-bottom: 4px;
+`;
+
+const CardTitle = styled.h3`
+  font-size: 14px;
+  font-weight: 800;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const CardDesc = styled.p`
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: ${({ theme }) => theme.colors.textMuted};
+  white-space: pre-line;
+`;

--- a/src/components/feature/LandingPage/TargetSection/TargetGrid.tsx
+++ b/src/components/feature/LandingPage/TargetSection/TargetGrid.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+import { TargetCard } from './TargetCard';
+import { TARGET_ITEMS } from '../../../../constants/targetItems';
+
+export function TargetGrid() {
+  return (
+    <Grid>
+      {TARGET_ITEMS.map((item) => (
+        <TargetCard
+          key={item.title}
+          img={item.img}
+          title={item.title}
+          desc={item.desc}
+        />
+      ))}
+    </Grid>
+  );
+}
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+`;

--- a/src/components/feature/LandingPage/TargetSection/TargetSection.tsx
+++ b/src/components/feature/LandingPage/TargetSection/TargetSection.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { TargetSectionHeader } from './TargetSectionHeader';
+import { TargetGrid } from './TargetGrid';
+
+export function TargetSection() {
+  return (
+    <Section>
+      <Inner>
+        <TargetSectionHeader />
+        <TargetGrid />
+      </Inner>
+    </Section>
+  );
+}
+
+const Section = styled.section`
+  width: 100%;
+  max-width: 420px;
+  padding: 32px 0 0;
+`;
+
+const Inner = styled.div`
+  background: ${({ theme }) => theme.colors.primarySoft};
+  border-radius: 22px;
+  padding: 28px 18px;
+`;

--- a/src/components/feature/LandingPage/TargetSection/TargetSectionHeader.tsx
+++ b/src/components/feature/LandingPage/TargetSection/TargetSectionHeader.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+export function TargetSectionHeader() {
+  return (
+    <>
+      <Eyebrow>이런 분들께 추천해요!</Eyebrow>
+      <Heading>
+        전세 계약을 앞둔 누구나,
+        <br />
+        안심하고 확인하세요.
+      </Heading>
+    </>
+  );
+}
+
+const Eyebrow = styled.p`
+  margin: 0 0 8px;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.primary};
+  font-size: 12px;
+  font-weight: 800;
+`;
+
+const Heading = styled.h2`
+  margin: 0 0 24px;
+  text-align: center;
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  color: ${({ theme }) => theme.colors.text};
+  line-height: 1.4;
+`;

--- a/src/constants/targetItems.ts
+++ b/src/constants/targetItems.ts
@@ -1,0 +1,33 @@
+import studentImg from '../assets/target-student.png';
+import coupleImg from '../assets/target-couple.png';
+import familyImg from '../assets/target-family.png';
+import investorImg from '../assets/target-investor.png';
+
+interface TargetItem {
+  img: string;
+  title: string;
+  desc: string;
+}
+
+export const TARGET_ITEMS: TargetItem[] = [
+  {
+    img: studentImg,
+    title: '사회초년생 / 대학생',
+    desc: '처음 계약하는 전세,\n꼼꼼히 확인하고 싶다면!',
+  },
+  {
+    img: coupleImg,
+    title: '신혼부부',
+    desc: '소중한 보금자리,\n안전하게 지키고 싶다면!',
+  },
+  {
+    img: familyImg,
+    title: '이사 계획 가족',
+    desc: '가족의 안전을 위해\n사전 점검은 필수!',
+  },
+  {
+    img: investorImg,
+    title: '투자자 / 집주인',
+    desc: '객관적인 정보로\n리스크를 줄이고 싶다면!',
+  },
+];

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { HeroSection } from '../../components/feature/LandingPage/HeroSection';
 import { FeatureSection } from '../../components/feature/LandingPage/FeatureSection/FeatureSection';
 import { StepSection } from '../../components/feature/LandingPage/StepSection/StepSection';
+import { TargetSection } from '../../components/feature/LandingPage/TargetSection/TargetSection';
 
 export function LandingPage() {
   return (
@@ -9,6 +10,7 @@ export function LandingPage() {
       <HeroSection />
       <FeatureSection />
       <StepSection />
+      <TargetSection />
     </PageWrapper>
   );
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #39 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- `targetItems.ts`
  - 카드 4종(사회초년생·대학생 / 신혼부부 / 이사 계획 가족 / 투자자·집주인) 데이터 상수로 분리
- `TargetSectionHeader.tsx`
  - Eyebrow + Heading 조합의 섹션 헤더 구현
- `TargetCard.tsx`
  - 공통 Card 컴포넌트 확장 (캐릭터 이미지 + 제목 + 설명)
- `TargetGrid.tsx`
  - 2×2 그리드 레이아웃 구현
- `TargetSection.tsx`
  - 위 컴포넌트 조합하여 섹션 완성
- `LandingPage.tsx`
  - StepSection 다음에 TargetSection 추가

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="424" height="623" alt="스크린샷 2026-05-05 오전 5 50 16" src="https://github.com/user-attachments/assets/edc44cf7-b1c4-4ac6-ab29-464027766c77" />

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### Card 컴포넌트 확장 방식
- 문제: 카드 UI가 공통 `Card`와 구조는 같지만 이미지가 추가되고 `padding·text-align`이 달랐습니다. 카드를 처음부터 새로 만들면 `shadow·radius·surface` 색상을 다시 선언해야 해서 중복이 생기고, theme 토큰과 동기화도 직접 관리해야 했습니다.
- 해결: `styled(Card)`로 확장해서 공통 스타일은 그대로 상속받고, `TargetCard`에서는 이미지·정렬·패딩만 덮어쓰는 방식을 택했습니다.
- 결과: `shadow·radius·surface` 같은 공통 토큰을 중복 선언하지 않아도 되고, 나중에 `Card`의 기본 스타일이 바뀌어도 `TargetCard`에 자동으로 반영되게 됐습니다.

### gap vs margin 혼용 문제
- 문제: 처음에는 `gap: 0` + Avatar `margin-bottom: 10px` + CardTitle `margin: 0 0 6px`을 각각 선언했습니다. Card가 기본적으로 `flex-direction: column + gap: 6px`를 가지고 있는데 `gap: 0`으로 초기화하고, 각 요소마다 margin을 직접 제어하다 보니 레이아웃 의도를 파악하기 어려운 구조가 됐습니다.
- 해결: `gap: 0`을 제거하고 `Card` 기본 `gap: 6px`를 그대로 활용했습니다. 이미지와 제목 사이에 추가 여백이 필요한 부분만 Avatar에 `margin-bottom: 4px`로 미세 조정했습니다.
- 결과: `Card`의 flex 레이아웃 흐름을 유지하면서, `margin` 선언이 꼭 필요한 곳에만 남게 돼 코드가 간결해졌습니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.
