### PR TITLE
[feat] PDF 업로드 카드 및 개인정보 마스킹 UI 구현 (#42, #43)

### DIFF
--- a/src/components/feature/InputPage/Step3/FileItemCard.tsx
+++ b/src/components/feature/InputPage/Step3/FileItemCard.tsx
@@ -1,0 +1,262 @@
+import styled from '@emotion/styled';
+import { Check, Trash2, TriangleAlert, CircleAlert } from 'lucide-react';
+import { useState } from 'react';
+import { Tag } from '../../../common/Tag';
+import { Button } from '../../../common/Button';
+import type { UploadedFile } from '../../../../constants/uploadedFile';
+
+const ICON_STROKE_WIDTH = 2.2;
+const STATUS_ICON_SIZE = 18;
+const ACTION_ICON_SIZE = 16;
+
+type FileItemCardProps = UploadedFile & {
+  onRemove: (id: string) => void;
+  dragHandle?: React.ReactNode;
+};
+
+function formatSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function FileItemCard({
+  id,
+  name,
+  size,
+  status,
+  issues,
+  onRemove,
+  dragHandle,
+}: FileItemCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleToggleExpand = () => setIsExpanded((prev) => !prev);
+
+  return (
+    <ItemWrap $status={status}>
+      <Row>
+        {dragHandle}
+
+        <StatusIconBox $status={status}>
+          {status === 'ok' ? (
+            <Check
+              size={STATUS_ICON_SIZE}
+              strokeWidth={ICON_STROKE_WIDTH}
+              aria-hidden="true"
+            />
+          ) : (
+            <TriangleAlert
+              size={STATUS_ICON_SIZE}
+              strokeWidth={ICON_STROKE_WIDTH}
+              aria-hidden="true"
+            />
+          )}
+        </StatusIconBox>
+
+        <Meta>
+          <FileName>{name}</FileName>
+          <SubRow>
+            {status === 'ok' ? (
+              <Tag variant="success">정상</Tag>
+            ) : (
+              <WarningBadge>주의 필요</WarningBadge>
+            )}
+            <Separator>·</Separator>
+            <FileSize>{formatSize(size)}</FileSize>
+          </SubRow>
+        </Meta>
+
+        <Actions>
+          {status === 'warning' && (
+            <AlertButton
+              type="button"
+              aria-label="문제 항목 보기"
+              onClick={handleToggleExpand}
+            >
+              <CircleAlert
+                size={ACTION_ICON_SIZE}
+                strokeWidth={ICON_STROKE_WIDTH}
+                aria-hidden="true"
+              />
+            </AlertButton>
+          )}
+          <Button
+            variant="ghost"
+            tone="black"
+            size="sm"
+            iconStart={
+              <Trash2
+                size={ACTION_ICON_SIZE}
+                strokeWidth={ICON_STROKE_WIDTH}
+                aria-hidden="true"
+              />
+            }
+            aria-label="파일 삭제"
+            onClick={() => onRemove(id)}
+          />
+        </Actions>
+      </Row>
+
+      {isExpanded && status === 'warning' && <FileIssuePanel issues={issues} />}
+    </ItemWrap>
+  );
+}
+
+interface FileIssuePanelProps {
+  issues: string[];
+}
+
+function FileIssuePanel({ issues }: FileIssuePanelProps) {
+  return (
+    <IssuePanel>
+      <IssueTitle>
+        <TriangleAlert
+          size={12}
+          strokeWidth={ICON_STROKE_WIDTH}
+          aria-hidden="true"
+        />
+        마스킹이 필요한 항목
+      </IssueTitle>
+      {issues.map((issue) => (
+        <IssueItem key={issue}>{issue}</IssueItem>
+      ))}
+    </IssuePanel>
+  );
+}
+
+const ItemWrap = styled.div<{ $status: 'ok' | 'warning' }>`
+  border-radius: ${({ theme }) => theme.radius.md};
+  border: 1px solid
+    ${({ theme, $status }) =>
+      $status === 'warning' ? theme.colors.dangerLight : theme.colors.border};
+  background: ${({ theme, $status }) =>
+    $status === 'warning' ? theme.colors.dangerBg : theme.colors.surface};
+  overflow: hidden;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+`;
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+`;
+
+const StatusIconBox = styled.div<{ $status: 'ok' | 'warning' }>`
+  width: 36px;
+  height: 36px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  background: ${({ theme, $status }) =>
+    $status === 'warning' ? theme.colors.dangerLight : theme.colors.successBg};
+  color: ${({ theme, $status }) =>
+    $status === 'warning' ? theme.colors.danger : theme.colors.success};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const Meta = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const FileName = styled.p`
+  font-size: 13px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.text};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 4px;
+`;
+
+const SubRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+const WarningBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 9px;
+  border-radius: ${({ theme }) => theme.radius.full};
+  font-size: 11px;
+  font-weight: 600;
+  background: ${({ theme }) => theme.colors.dangerLight};
+  color: ${({ theme }) => theme.colors.danger};
+`;
+
+const Separator = styled.span`
+  font-size: 11px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const FileSize = styled.span`
+  font-size: 11px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 2px;
+`;
+
+const AlertButton = styled.button`
+  width: 28px;
+  height: 28px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.danger};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+
+  &:hover:not(:disabled),
+  &:active:not(:disabled) {
+    background: ${({ theme }) => theme.colors.dangerBg};
+  }
+`;
+
+const IssuePanel = styled.div`
+  border-top: 1px dashed ${({ theme }) => theme.colors.dangerLight};
+  background: ${({ theme }) => theme.colors.surface};
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const IssueTitle = styled.p`
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 800;
+  color: ${({ theme }) => theme.colors.danger};
+  margin-bottom: 2px;
+`;
+
+const IssueItem = styled.p`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.textSub};
+
+  &::before {
+    content: '';
+    width: 5px;
+    height: 5px;
+    border-radius: ${({ theme }) => theme.radius.full};
+    background: ${({ theme }) => theme.colors.danger};
+    flex-shrink: 0;
+  }
+`;

--- a/src/components/feature/InputPage/Step3/FileUploader.tsx
+++ b/src/components/feature/InputPage/Step3/FileUploader.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import { FileUploaderCard } from './FileUploaderCard';
+import { PrivacyMaskingBanner } from './PrivacyMaskingBanner';
+import { PrivacyMaskingToggle } from './PrivacyMaskingToggle';
+import type {
+  FileMap,
+  UploadedFile,
+  UploaderKey,
+} from '../../../../constants/uploadedFile';
+import { UPLOADER_CONFIGS } from '../../../../constants/uploadedFile';
+
+interface FileUploaderProps {
+  isMaskingConfirmed: boolean;
+  onMaskingConfirmChange: (confirmed: boolean) => void;
+  files: FileMap;
+  onFilesChange: (key: UploaderKey, files: UploadedFile[]) => void;
+}
+
+function hasWarningFiles(files: FileMap) {
+  return Object.values(files).some((list) =>
+    list.some((f) => f.status === 'warning'),
+  );
+}
+
+export function FileUploader({
+  isMaskingConfirmed,
+  onMaskingConfirmChange,
+  files,
+  onFilesChange,
+}: FileUploaderProps) {
+  const showMaskingSection = hasWarningFiles(files);
+
+  return (
+    <Wrap>
+      {UPLOADER_CONFIGS.map((config) => (
+        <FileUploaderCard
+          key={config.key}
+          config={config}
+          files={files[config.key]}
+          onChange={(next) => onFilesChange(config.key, next)}
+        />
+      ))}
+
+      {showMaskingSection && (
+        <MaskingSection>
+          <PrivacyMaskingBanner />
+          <PrivacyMaskingToggle
+            checked={isMaskingConfirmed}
+            onChange={onMaskingConfirmChange}
+          />
+        </MaskingSection>
+      )}
+    </Wrap>
+  );
+}
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const MaskingSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;

--- a/src/components/feature/InputPage/Step3/FileUploaderCard.tsx
+++ b/src/components/feature/InputPage/Step3/FileUploaderCard.tsx
@@ -1,0 +1,115 @@
+import styled from '@emotion/styled';
+import { useRef } from 'react';
+import { Card } from '../../../common/Card';
+import { UploaderCardHeader } from './UploaderCardHeader';
+import { UploaderCounterBar } from './UploaderCounterBar';
+import { UploaderEmptyDropZone } from './UploaderEmptyDropZone';
+import { UploaderFileList } from './UploaderFileList';
+import type {
+  UploadedFile,
+  UploaderConfig,
+} from '../../../../constants/uploadedFile';
+import { PRIVACY_ISSUE_KEYS } from '../../../../constants/uploadedFile';
+
+interface FileUploaderCardProps {
+  config: UploaderConfig;
+  files: UploadedFile[];
+  onChange: (files: UploadedFile[]) => void;
+}
+
+function inspectFile(name: string): Pick<UploadedFile, 'status' | 'issues'> {
+  const looksUnmasked = /원본|raw|unmask|개인/.test(name);
+  const flagged = name.length % 3 === 0;
+  if (looksUnmasked || flagged) {
+    const issues = PRIVACY_ISSUE_KEYS.filter(
+      (_, i) => (name.length + i) % 2 === 0,
+    ).slice(0, 3);
+    return {
+      status: 'warning',
+      issues: issues.length ? [...issues] : ['주민등록번호 일부 노출'],
+    };
+  }
+  return { status: 'ok', issues: [] };
+}
+
+export function FileUploaderCard({
+  config,
+  files,
+  onChange,
+}: FileUploaderCardProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const openPicker = () => inputRef.current?.click();
+
+  const handleFiles = (list: FileList | null) => {
+    if (!list || !list.length) return;
+    const next: UploadedFile[] = Array.from(list).map((f, i) => ({
+      id: `${Date.now()}-${i}-${f.name}`,
+      name: f.name,
+      size: f.size,
+      ...inspectFile(f.name),
+    }));
+    onChange([...files, ...next]);
+    if (inputRef.current) inputRef.current.value = '';
+  };
+
+  const handleRemove = (id: string) => {
+    onChange(files.filter((f) => f.id !== id));
+  };
+
+  return (
+    <StyledCard>
+      <UploaderCardHeader
+        Icon={config.Icon}
+        title={config.title}
+        desc={config.desc}
+      />
+
+      <Divider />
+
+      <Body>
+        <UploaderCounterBar count={files.length} onAdd={openPicker} />
+
+        <HiddenInput
+          ref={inputRef}
+          type="file"
+          multiple
+          accept="application/pdf,image/*"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+
+        {files.length === 0 ? (
+          <UploaderEmptyDropZone onClick={openPicker} />
+        ) : (
+          <UploaderFileList
+            files={files}
+            onRemove={handleRemove}
+            onReorder={onChange}
+          />
+        )}
+      </Body>
+    </StyledCard>
+  );
+}
+
+const StyledCard = styled(Card)`
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+`;
+
+const Divider = styled.div`
+  height: 1px;
+  background: ${({ theme }) => theme.colors.borderLight};
+`;
+
+const Body = styled.div`
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const HiddenInput = styled.input`
+  display: none;
+`;

--- a/src/components/feature/InputPage/Step3/PrivacyMaskingBanner.tsx
+++ b/src/components/feature/InputPage/Step3/PrivacyMaskingBanner.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { CircleAlert } from 'lucide-react';
+import { PRIVACY_WARNING_MESSAGE } from '../../../../constants/uploadedFile';
+
+const ICON_SIZE = 16;
+const ICON_STROKE_WIDTH = 2.2;
+
+export function PrivacyMaskingBanner() {
+  return (
+    <Banner>
+      <CircleAlert
+        size={ICON_SIZE}
+        strokeWidth={ICON_STROKE_WIDTH}
+        aria-hidden="true"
+      />
+      <BannerText>{PRIVACY_WARNING_MESSAGE}</BannerText>
+    </Banner>
+  );
+}
+
+const Banner = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: ${({ theme }) => theme.radius.md};
+  background: ${({ theme }) => theme.colors.warningBg};
+  border: 1px solid ${({ theme }) => theme.colors.warningLight};
+  color: ${({ theme }) => theme.colors.warning};
+`;
+
+const BannerText = styled.p`
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.6;
+  white-space: pre-line;
+`;

--- a/src/components/feature/InputPage/Step3/PrivacyMaskingToggle.tsx
+++ b/src/components/feature/InputPage/Step3/PrivacyMaskingToggle.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+import { Check } from 'lucide-react';
+
+interface PrivacyMaskingToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function PrivacyMaskingToggle({
+  checked,
+  onChange,
+}: PrivacyMaskingToggleProps) {
+  return (
+    <ToggleRow
+      role="checkbox"
+      aria-checked={checked}
+      tabIndex={0}
+      onClick={() => onChange(!checked)}
+      onKeyDown={(e) => {
+        if (e.key === ' ' || e.key === 'Enter') onChange(!checked);
+      }}
+    >
+      <ToggleLabel>개인정보를 모두 가렸어요</ToggleLabel>
+      <Checkbox $checked={checked} aria-hidden="true">
+        {checked && <Check size={12} strokeWidth={3} aria-hidden="true" />}
+      </Checkbox>
+    </ToggleRow>
+  );
+}
+
+const ToggleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: ${({ theme }) => theme.radius.md};
+  background: ${({ theme }) => theme.colors.surface};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+
+  &:hover,
+  &:active {
+    border-color: ${({ theme }) => theme.colors.primary};
+    background: ${({ theme }) => theme.colors.primarySoft};
+  }
+`;
+
+const ToggleLabel = styled.p`
+  flex: 1;
+  font-size: 13px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Checkbox = styled.div<{ $checked: boolean }>`
+  width: 22px;
+  height: 22px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  border: 1.5px solid
+    ${({ theme, $checked }) =>
+      $checked ? theme.colors.primary : theme.colors.border};
+  background: ${({ theme, $checked }) =>
+    $checked ? theme.colors.primary : theme.colors.surface};
+  color: ${({ theme }) => theme.colors.surface};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+`;

--- a/src/components/feature/InputPage/Step3/UploaderCardHeader.tsx
+++ b/src/components/feature/InputPage/Step3/UploaderCardHeader.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import { Card } from '../../../common/Card';
+import type { UploaderConfig } from '../../../../constants/uploadedFile';
+
+const ICON_SIZE = 18;
+const ICON_STROKE_WIDTH = 2.2;
+
+type UploaderCardHeaderProps = Pick<UploaderConfig, 'Icon' | 'title' | 'desc'>;
+
+export function UploaderCardHeader({
+  Icon,
+  title,
+  desc,
+}: UploaderCardHeaderProps) {
+  return (
+    <Header>
+      <IconBox>
+        <Icon
+          size={ICON_SIZE}
+          strokeWidth={ICON_STROKE_WIDTH}
+          aria-hidden="true"
+        />
+      </IconBox>
+      <TextWrap>
+        <Title>{title}</Title>
+        <Desc>{desc}</Desc>
+      </TextWrap>
+    </Header>
+  );
+}
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px;
+`;
+
+const IconBox = styled(Card)`
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  gap: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: ${({ theme }) => theme.colors.primarySoft};
+  color: ${({ theme }) => theme.colors.primary};
+`;
+
+const TextWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const Title = styled.h3`
+  font-size: 14px;
+  font-weight: 800;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Desc = styled.p`
+  font-size: 11.5px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;

--- a/src/components/feature/InputPage/Step3/UploaderCounterBar.tsx
+++ b/src/components/feature/InputPage/Step3/UploaderCounterBar.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+import { Plus } from 'lucide-react';
+import { Button } from '../../../common/Button';
+
+interface UploaderCounterBarProps {
+  count: number;
+  onAdd: () => void;
+}
+
+export function UploaderCounterBar({ count, onAdd }: UploaderCounterBarProps) {
+  return (
+    <Bar>
+      <Counter>
+        업로드된 파일 <CountNum>{count}</CountNum>개
+      </Counter>
+      {count > 0 && (
+        <Button
+          variant="dashed"
+          size="sm"
+          iconStart={<Plus size={12} strokeWidth={3} aria-hidden="true" />}
+          onClick={onAdd}
+        >
+          파일 추가
+        </Button>
+      )}
+    </Bar>
+  );
+}
+
+const Bar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Counter = styled.p`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const CountNum = styled.span`
+  color: ${({ theme }) => theme.colors.primary};
+  font-weight: 800;
+`;

--- a/src/components/feature/InputPage/Step3/UploaderEmptyDropZone.tsx
+++ b/src/components/feature/InputPage/Step3/UploaderEmptyDropZone.tsx
@@ -1,0 +1,56 @@
+import styled from '@emotion/styled';
+import { Plus } from 'lucide-react';
+
+const ICON_SIZE = 22;
+const ICON_STROKE_WIDTH = 1.8;
+
+interface UploaderEmptyDropZoneProps {
+  onClick: () => void;
+}
+
+export function UploaderEmptyDropZone({ onClick }: UploaderEmptyDropZoneProps) {
+  return (
+    <DropZone type="button" onClick={onClick}>
+      <Plus
+        size={ICON_SIZE}
+        strokeWidth={ICON_STROKE_WIDTH}
+        aria-hidden="true"
+      />
+      <HintText>여기를 눌러 파일을 업로드하세요</HintText>
+      <SubHint>PDF · 여러 장 가능</SubHint>
+    </DropZone>
+  );
+}
+
+const DropZone = styled.button`
+  width: 100%;
+  border: 1.5px dashed ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.bg};
+  border-radius: ${({ theme }) => theme.radius.md};
+  padding: 28px 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  color: ${({ theme }) => theme.colors.textMuted};
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+
+  &:hover:not(:disabled),
+  &:active:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.primary};
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+const HintText = styled.p`
+  font-size: 13px;
+  font-weight: 600;
+  color: inherit;
+`;
+
+const SubHint = styled.p`
+  font-size: 11px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;

--- a/src/components/feature/InputPage/Step3/UploaderFileList.tsx
+++ b/src/components/feature/InputPage/Step3/UploaderFileList.tsx
@@ -1,0 +1,94 @@
+import styled from '@emotion/styled';
+import { GripVertical } from 'lucide-react';
+import { FileItemCard } from './FileItemCard';
+import { useDragSort } from '../../../../hooks/useDragSort';
+import type { UploadedFile } from '../../../../constants/uploadedFile';
+
+const GRIP_SIZE = 16;
+const GRIP_STROKE_WIDTH = 2;
+
+interface UploaderFileListProps {
+  files: UploadedFile[];
+  onRemove: (id: string) => void;
+  onReorder: (files: UploadedFile[]) => void;
+}
+
+export function UploaderFileList({
+  files,
+  onRemove,
+  onReorder,
+}: UploaderFileListProps) {
+  const { draggingIdx, overIdx, getItemHandlers } = useDragSort({
+    items: files,
+    onReorder,
+  });
+
+  return (
+    <List>
+      {files.map((file, idx) => {
+        const handlers = getItemHandlers(idx);
+        const isDragging = draggingIdx === idx;
+        const isOver =
+          overIdx === idx && draggingIdx !== null && draggingIdx !== idx;
+
+        return (
+          <ItemWrapper
+            key={file.id}
+            $isDragging={isDragging}
+            $isOver={isOver}
+            draggable
+            {...handlers}
+          >
+            <FileItemCard
+              {...file}
+              onRemove={onRemove}
+              dragHandle={
+                <DragHandle aria-label="드래그하여 순서 변경">
+                  <GripVertical
+                    size={GRIP_SIZE}
+                    strokeWidth={GRIP_STROKE_WIDTH}
+                    aria-hidden="true"
+                  />
+                </DragHandle>
+              }
+            />
+          </ItemWrapper>
+        );
+      })}
+    </List>
+  );
+}
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const ItemWrapper = styled.div<{ $isDragging: boolean; $isOver: boolean }>`
+  opacity: ${({ $isDragging }) => ($isDragging ? 0.4 : 1)};
+  border-radius: ${({ theme }) => theme.radius.md};
+  outline: ${({ theme, $isOver }) =>
+    $isOver ? `2px solid ${theme.colors.primary}` : 'none'};
+  outline-offset: 1px;
+  transition:
+    opacity 0.15s,
+    outline 0.1s;
+  touch-action: none;
+`;
+
+const DragHandle = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 30px;
+  color: ${({ theme }) => theme.colors.textMuted};
+  cursor: grab;
+  flex-shrink: 0;
+  touch-action: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+`;

--- a/src/constants/uploadedFile.ts
+++ b/src/constants/uploadedFile.ts
@@ -1,0 +1,49 @@
+import type { LucideIcon } from 'lucide-react';
+import { File, Signature } from 'lucide-react';
+
+export type FileStatus = 'ok' | 'warning';
+
+export interface UploadedFile {
+  id: string;
+  name: string;
+  size: number;
+  status: FileStatus;
+  issues: string[];
+}
+
+export type UploaderKey = 'registry' | 'contract';
+
+export interface UploaderConfig {
+  key: UploaderKey;
+  Icon: LucideIcon;
+  title: string;
+  desc: string;
+}
+
+export const UPLOADER_CONFIGS: UploaderConfig[] = [
+  {
+    key: 'registry',
+    Icon: File,
+    title: '등기부등본',
+    desc: '등기부등본 PDF를 업로드해주세요',
+  },
+  {
+    key: 'contract',
+    Icon: Signature,
+    title: '임대차계약서',
+    desc: '임대차계약서 PDF를 업로드해주세요',
+  },
+];
+
+export const PRIVACY_ISSUE_KEYS = [
+  '주민등록번호',
+  '연락처',
+  '계좌번호',
+  '이메일',
+  '생년월일',
+] as const;
+
+export type FileMap = Record<UploaderKey, UploadedFile[]>;
+
+export const PRIVACY_WARNING_MESSAGE =
+  '개인정보 마스킹이 필요한 파일이 있어요.\n카드의 ⓘ 아이콘을 눌러 확인해주세요.';

--- a/src/hooks/useDragSort.ts
+++ b/src/hooks/useDragSort.ts
@@ -1,0 +1,103 @@
+import { useRef, useState } from 'react';
+
+interface UseDragSortOptions<T> {
+  items: T[];
+  onReorder: (next: T[]) => void;
+}
+
+interface DragHandlers {
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+  onDragLeave: () => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+}
+
+interface UseDragSortResult {
+  draggingIdx: number | null;
+  overIdx: number | null;
+  getItemHandlers: (idx: number) => DragHandlers;
+}
+
+export function useDragSort<T>({
+  items,
+  onReorder,
+}: UseDragSortOptions<T>): UseDragSortResult {
+  const [draggingIdx, setDraggingIdx] = useState<number | null>(null);
+  const [overIdx, setOverIdx] = useState<number | null>(null);
+
+  const touchDraggingIdxRef = useRef<number | null>(null);
+  const itemHeightRef = useRef<number>(0);
+  const listTopRef = useRef<number>(0);
+
+  const reorder = (from: number, to: number) => {
+    if (from === to) return;
+    const next = [...items];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    onReorder(next);
+  };
+
+  const getItemHandlers = (idx: number): DragHandlers => ({
+    onDragStart(e) {
+      setDraggingIdx(idx);
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', String(idx));
+    },
+    onDragOver(e) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      if (overIdx !== idx) setOverIdx(idx);
+    },
+    onDrop(e) {
+      e.preventDefault();
+      if (draggingIdx !== null && draggingIdx !== idx) {
+        reorder(draggingIdx, idx);
+      }
+      setDraggingIdx(null);
+      setOverIdx(null);
+    },
+    onDragEnd() {
+      setDraggingIdx(null);
+      setOverIdx(null);
+    },
+    onDragLeave() {
+      setOverIdx((cur) => (cur === idx ? null : cur));
+    },
+
+    onTouchStart(e) {
+      const target = e.currentTarget as HTMLElement;
+      const rect = target.getBoundingClientRect();
+      // gap 8px을 포함한 아이템 높이로 터치 이동 중 타깃 인덱스를 계산
+      itemHeightRef.current = rect.height + 8;
+      listTopRef.current =
+        target.parentElement?.getBoundingClientRect().top ?? rect.top;
+      touchDraggingIdxRef.current = idx;
+      setDraggingIdx(idx);
+    },
+    onTouchMove(e) {
+      e.preventDefault();
+      const touch = e.touches[0];
+      const offsetFromListTop = touch.clientY - listTopRef.current;
+      const targetIdx = Math.min(
+        items.length - 1,
+        Math.max(0, Math.floor(offsetFromListTop / itemHeightRef.current)),
+      );
+      if (overIdx !== targetIdx) setOverIdx(targetIdx);
+    },
+    onTouchEnd() {
+      const from = touchDraggingIdxRef.current;
+      if (from !== null && overIdx !== null && from !== overIdx) {
+        reorder(from, overIdx);
+      }
+      setDraggingIdx(null);
+      setOverIdx(null);
+      touchDraggingIdxRef.current = null;
+    },
+  });
+
+  return { draggingIdx, overIdx, getItemHandlers };
+}

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -3,10 +3,21 @@ import { useState } from 'react';
 import { Button } from '../../components/common/Button';
 import { AddressSection } from './AddressSection';
 import { ContractSection } from './ContractSection';
+import { UploadSection } from './UploadSection';
 import type { ContractType } from '../../constants/contract';
 import type { Address } from '../../types/address';
+import type {
+  FileMap,
+  UploadedFile,
+  UploaderKey,
+} from '../../constants/uploadedFile';
 
-const INPUT_STEPS = ['address', 'contract'] as const;
+const INPUT_STEPS = ['address', 'contract', 'upload'] as const;
+
+const INITIAL_FILES: FileMap = {
+  registry: [],
+  contract: [],
+};
 
 export function InputPage() {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
@@ -15,14 +26,28 @@ export function InputPage() {
   const [deposit, setDeposit] = useState('');
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [endDate, setEndDate] = useState<Date | null>(null);
+  const [files, setFiles] = useState<FileMap>(INITIAL_FILES);
+  const [isMaskingConfirmed, setIsMaskingConfirmed] = useState(false);
+
   const currentStep = INPUT_STEPS[currentStepIndex];
+
   const isAddressStepNextDisabled = selectedAddress === null;
+
+  const hasWarningFiles = Object.values(files).some((list) =>
+    list.some((f) => f.status === 'warning'),
+  );
+  const isUploadStepNextDisabled = hasWarningFiles && !isMaskingConfirmed;
+
   const handleNext = () => {
     setCurrentStepIndex((prev) => Math.min(prev + 1, INPUT_STEPS.length - 1));
   };
 
   const handlePrev = () => {
     setCurrentStepIndex((prev) => Math.max(prev - 1, 0));
+  };
+
+  const handleFilesChange = (key: UploaderKey, next: UploadedFile[]) => {
+    setFiles((prev) => ({ ...prev, [key]: next }));
   };
 
   return (
@@ -76,6 +101,38 @@ export function InputPage() {
               size="lg"
               width="100%"
               onClick={handleNext}
+            >
+              다음
+            </Button>
+          </ButtonArea>
+        </>
+      )}
+
+      {currentStep === 'upload' && (
+        <>
+          <UploadSection
+            files={files}
+            onFilesChange={handleFilesChange}
+            isMaskingConfirmed={isMaskingConfirmed}
+            onMaskingConfirmChange={setIsMaskingConfirmed}
+          />
+
+          <ButtonArea>
+            <Button
+              variant="outline"
+              size="lg"
+              width="100%"
+              onClick={handlePrev}
+            >
+              이전
+            </Button>
+
+            <Button
+              variant="primary"
+              size="lg"
+              width="100%"
+              onClick={handleNext}
+              disabled={isUploadStepNextDisabled}
             >
               다음
             </Button>

--- a/src/pages/InputPage/UploadSection.tsx
+++ b/src/pages/InputPage/UploadSection.tsx
@@ -1,0 +1,29 @@
+import { FileUploader } from '../../components/feature/InputPage/Step3/FileUploader';
+import type {
+  FileMap,
+  UploadedFile,
+  UploaderKey,
+} from '../../constants/uploadedFile';
+
+interface UploadSectionProps {
+  files: FileMap;
+  onFilesChange: (key: UploaderKey, files: UploadedFile[]) => void;
+  isMaskingConfirmed: boolean;
+  onMaskingConfirmChange: (confirmed: boolean) => void;
+}
+
+export function UploadSection({
+  files,
+  onFilesChange,
+  isMaskingConfirmed,
+  onMaskingConfirmChange,
+}: UploadSectionProps) {
+  return (
+    <FileUploader
+      files={files}
+      onFilesChange={onFilesChange}
+      isMaskingConfirmed={isMaskingConfirmed}
+      onMaskingConfirmChange={onMaskingConfirmChange}
+    />
+  );
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #42
- Closes #43

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 3h 30m
- 실제 작업 시간 : 4h 

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

### 컴포넌트 구조 (아래 → 위 조합 순서)

- `uploadedFile.ts`
  - `UploadedFile`, `FileStatus`, `FileMap`, `UploaderConfig` 타입 정의
  - `UPLOADER_CONFIGS`: 등기부등본(File 아이콘), 임대차계약서(Signature 아이콘) 설정 상수
  - `PRIVACY_ISSUE_KEYS`, `PRIVACY_WARNING_MESSAGE` 상수 분리
- `useDragSort.ts`
  - PC 드래그(HTML5 Drag & Drop) + 모바일 터치 순서 조정 전용 훅
- `UploaderCardHeader.tsx` — 아이콘 박스 + 제목 + 설명
- `UploaderCounterBar.tsx` — 파일 수 카운터 + 파일 추가 버튼
- `UploaderEmptyDropZone.tsx` — 파일 없을 때 점선 클릭 영역
- `UploaderFileList.tsx` — 파일 목록, `useDragSort` 연결, GripVertical 핸들
- `FileItemCard.tsx`
  - 파일 한 개 행 — 상태 아이콘(정상/주의), 파일명, 배지, 용량 표시
  - 주의 파일: ⓘ 버튼 클릭 시 IssuePanel(마스킹 필요 항목 목록) 토글
  - 삭제: 공통 `Button variant="ghost" tone="black"` 활용
- `FileUploaderCard.tsx` — 위 컴포넌트 조합, 파일 추가·삭제·inspectFile 처리
- `PrivacyMaskingBanner.tsx` — 주의 파일 있을 때 경고 배너
- `PrivacyMaskingToggle.tsx` — "개인정보를 모두 가렸어요" 체크 토글
- `FileUploader.tsx` — 두 업로더 카드 + 마스킹 섹션 조합
- `UploadSection.tsx` — FileUploader를 페이지에 끼워주는 래퍼
- `InputPage.tsx` — upload 스텝 추가, 마스킹 미확인 시 다음 버튼 disabled

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="960" height="1281" alt="화면 기록 2026-05-06 오후 7 59 16" src="https://github.com/user-attachments/assets/de42f0d4-1f37-479d-89ba-4b14599452ed" />

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### PC와 모바일 드래그 동시 지원

- 문제: HTML5 Drag & Drop API는 모바일에서 동작하지 않습니다. 모바일이 주 타깃인 서비스인데 파일 순서 조정이 PC에서만 되면 의미가 없었습니다.
- 해결: PC는 `dragstart/dragover/drop/dragend`, 모바일은 `touchstart/touchmove/touchend`를 별도로 구현하고, 두 이벤트 핸들러를 `useDragSort` 훅으로 묶어 `UploaderFileList`에서 한 번에 연결했습니다. 터치 이동 중 스크롤 간섭을 막기 위해 `touch-action: none`도 적용했습니다.
- 결과: 마우스 드래그와 터치 드래그 모두 동일한 순서 조정 경험을 제공하고, 드래그 관련 로직이 컴포넌트 바깥 훅으로 분리되어 `UploaderFileList`는 렌더링에만 집중할 수 있게 됐습니다.


<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- `useDragSort`의 모바일 터치 인덱스 계산 방식(`itemHeight + gap 8px` 기반)이 실제 기기에서도 자연스럽게 동작할지?

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.
