### PR TITLE
[feat] 2단계 소유자 확인 섹션 및 하단 액션 영역 구현 (#44, #45)

### DIFF
--- a/src/components/feature/InputPage/Step3/FileUploader.tsx
+++ b/src/components/feature/InputPage/Step3/FileUploader.tsx
@@ -43,7 +43,7 @@ export function FileUploader({
 
       {showMaskingSection && (
         <MaskingSection>
-          <PrivacyMaskingBanner />
+          {!isMaskingConfirmed && <PrivacyMaskingBanner />}
           <PrivacyMaskingToggle
             checked={isMaskingConfirmed}
             onChange={onMaskingConfirmChange}

--- a/src/components/feature/InputPage/Step3/OwnerVerifyBanner.tsx
+++ b/src/components/feature/InputPage/Step3/OwnerVerifyBanner.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import { TriangleAlert } from 'lucide-react';
+
+const ICON_SIZE = 16;
+const ICON_STROKE_WIDTH = 2.4;
+
+export function OwnerVerifyBanner() {
+  return (
+    <Banner>
+      <IconBox>
+        <TriangleAlert
+          size={ICON_SIZE}
+          strokeWidth={ICON_STROKE_WIDTH}
+          aria-hidden="true"
+        />
+      </IconBox>
+      <Body>
+        <h4>소유자 일치 확인</h4>
+        <p>계약서상 임대인과 등기부등본상 소유자가 같은지 직접 확인해주세요.</p>
+        <p>이름, 공동소유 여부, 대리인 계약 여부 등을 꼼꼼히 살펴보세요.</p>
+      </Body>
+    </Banner>
+  );
+}
+
+const Banner = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  border-radius: ${({ theme }) => theme.radius.lg};
+  background: ${({ theme }) => theme.colors.warningBg};
+  border: 1px solid ${({ theme }) => theme.colors.warningLight};
+`;
+
+const IconBox = styled.div`
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.warningLight};
+  color: ${({ theme }) => theme.colors.warning};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const Body = styled.div`
+  flex: 1;
+
+  > h4 {
+    font-size: 13.5px;
+    font-weight: 800;
+    color: #92400e;
+    margin-bottom: 6px;
+  }
+
+  > p {
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: #92400e;
+
+    & + p {
+      margin-top: 4px;
+    }
+  }
+`;

--- a/src/components/feature/InputPage/Step3/OwnerVerifySection.tsx
+++ b/src/components/feature/InputPage/Step3/OwnerVerifySection.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { OwnerVerifyBanner } from './OwnerVerifyBanner';
+import { OwnerVerifyToggle } from './OwnerVerifyToggle';
+
+interface OwnerVerifySectionProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function OwnerVerifySection({
+  checked,
+  onChange,
+}: OwnerVerifySectionProps) {
+  return (
+    <Wrap>
+      <OwnerVerifyBanner />
+      <OwnerVerifyToggle checked={checked} onChange={onChange} />
+    </Wrap>
+  );
+}
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;

--- a/src/components/feature/InputPage/Step3/OwnerVerifyToggle.tsx
+++ b/src/components/feature/InputPage/Step3/OwnerVerifyToggle.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+import { Check } from 'lucide-react';
+
+interface OwnerVerifyToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function OwnerVerifyToggle({
+  checked,
+  onChange,
+}: OwnerVerifyToggleProps) {
+  return (
+    <ToggleRow
+      role="checkbox"
+      aria-checked={checked}
+      tabIndex={0}
+      onClick={() => onChange(!checked)}
+      onKeyDown={(e) => {
+        if (e.key === ' ' || e.key === 'Enter') onChange(!checked);
+      }}
+    >
+      <ToggleLabel>소유자 일치 확인 완료</ToggleLabel>
+      <Checkbox $checked={checked} aria-hidden="true">
+        {checked && <Check size={12} strokeWidth={3} aria-hidden="true" />}
+      </Checkbox>
+    </ToggleRow>
+  );
+}
+
+const ToggleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: ${({ theme }) => theme.radius.md};
+  background: ${({ theme }) => theme.colors.surface};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+
+  &:hover,
+  &:active {
+    border-color: ${({ theme }) => theme.colors.primary};
+    background: ${({ theme }) => theme.colors.primarySoft};
+  }
+`;
+
+const ToggleLabel = styled.p`
+  flex: 1;
+  font-size: 13px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Checkbox = styled.div<{ $checked: boolean }>`
+  width: 22px;
+  height: 22px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  border: 1.5px solid
+    ${({ theme, $checked }) =>
+      $checked ? theme.colors.primary : theme.colors.border};
+  background: ${({ theme, $checked }) =>
+    $checked ? theme.colors.primary : theme.colors.surface};
+  color: ${({ theme }) => theme.colors.surface};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+`;

--- a/src/components/feature/InputPage/Step3/PrivacyMaskingBanner.tsx
+++ b/src/components/feature/InputPage/Step3/PrivacyMaskingBanner.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import { CircleAlert } from 'lucide-react';
-import { PRIVACY_WARNING_MESSAGE } from '../../../../constants/uploadedFile';
 
 const ICON_SIZE = 16;
 const ICON_STROKE_WIDTH = 2.2;
@@ -8,12 +7,18 @@ const ICON_STROKE_WIDTH = 2.2;
 export function PrivacyMaskingBanner() {
   return (
     <Banner>
-      <CircleAlert
-        size={ICON_SIZE}
-        strokeWidth={ICON_STROKE_WIDTH}
-        aria-hidden="true"
-      />
-      <BannerText>{PRIVACY_WARNING_MESSAGE}</BannerText>
+      <IconBox>
+        <CircleAlert
+          size={ICON_SIZE}
+          strokeWidth={ICON_STROKE_WIDTH}
+          aria-hidden="true"
+        />
+      </IconBox>
+      <Body>
+        <h4>개인정보 마스킹 필요</h4>
+        <p>개인정보 마스킹이 필요한 파일이 있어요.</p>
+        <p>카드의 ⓘ 아이콘을 눌러 확인해주세요.</p>
+      </Body>
     </Banner>
   );
 }
@@ -21,17 +26,42 @@ export function PrivacyMaskingBanner() {
 const Banner = styled.div`
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  padding: 12px 14px;
-  border-radius: ${({ theme }) => theme.radius.md};
+  gap: 12px;
+  padding: 16px;
+  border-radius: ${({ theme }) => theme.radius.lg};
   background: ${({ theme }) => theme.colors.warningBg};
   border: 1px solid ${({ theme }) => theme.colors.warningLight};
-  color: ${({ theme }) => theme.colors.warning};
 `;
 
-const BannerText = styled.p`
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 1.6;
-  white-space: pre-line;
+const IconBox = styled.div`
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.warningLight};
+  color: ${({ theme }) => theme.colors.warning};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const Body = styled.div`
+  flex: 1;
+
+  > h4 {
+    font-size: 13.5px;
+    font-weight: 800;
+    color: #92400e;
+    margin-bottom: 6px;
+  }
+
+  > p {
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: #92400e;
+
+    & + p {
+      margin-top: 4px;
+    }
+  }
 `;

--- a/src/components/feature/InputPage/Step3/UploadAutoDeleteNotice.tsx
+++ b/src/components/feature/InputPage/Step3/UploadAutoDeleteNotice.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import { Lock } from 'lucide-react';
+
+const ICON_SIZE = 12;
+const ICON_STROKE_WIDTH = 2.2;
+
+export function UploadAutoDeleteNotice() {
+  return (
+    <Notice>
+      <Lock
+        size={ICON_SIZE}
+        strokeWidth={ICON_STROKE_WIDTH}
+        aria-hidden="true"
+      />
+      업로드된 파일은 분석 후 자동 삭제돼요
+    </Notice>
+  );
+}
+
+const Notice = styled.p`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '../../components/common/Button';
 import { AddressSection } from './AddressSection';
 import { ContractSection } from './ContractSection';
@@ -20,6 +21,7 @@ const INITIAL_FILES: FileMap = {
 };
 
 export function InputPage() {
+  const navigate = useNavigate();
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [selectedAddress, setSelectedAddress] = useState<Address | null>(null);
   const [contractType, setContractType] = useState<ContractType>('jeonse');
@@ -28,6 +30,7 @@ export function InputPage() {
   const [endDate, setEndDate] = useState<Date | null>(null);
   const [files, setFiles] = useState<FileMap>(INITIAL_FILES);
   const [isMaskingConfirmed, setIsMaskingConfirmed] = useState(false);
+  const [isOwnerVerifyConfirmed, setIsOwnerVerifyConfirmed] = useState(false);
 
   const currentStep = INPUT_STEPS[currentStepIndex];
 
@@ -36,9 +39,14 @@ export function InputPage() {
   const hasWarningFiles = Object.values(files).some((list) =>
     list.some((f) => f.status === 'warning'),
   );
-  const isUploadStepNextDisabled = hasWarningFiles && !isMaskingConfirmed;
+  const isUploadStepNextDisabled =
+    (hasWarningFiles && !isMaskingConfirmed) || !isOwnerVerifyConfirmed;
 
   const handleNext = () => {
+    if (currentStep === 'upload') {
+      navigate('/analyze');
+      return;
+    }
     setCurrentStepIndex((prev) => Math.min(prev + 1, INPUT_STEPS.length - 1));
   };
 
@@ -47,6 +55,7 @@ export function InputPage() {
   };
 
   const handleFilesChange = (key: UploaderKey, next: UploadedFile[]) => {
+    if (next.length > files[key].length) setIsMaskingConfirmed(false);
     setFiles((prev) => ({ ...prev, [key]: next }));
   };
 
@@ -115,6 +124,8 @@ export function InputPage() {
             onFilesChange={handleFilesChange}
             isMaskingConfirmed={isMaskingConfirmed}
             onMaskingConfirmChange={setIsMaskingConfirmed}
+            isOwnerVerifyConfirmed={isOwnerVerifyConfirmed}
+            onOwnerVerifyConfirmChange={setIsOwnerVerifyConfirmed}
           />
 
           <ButtonArea>
@@ -134,7 +145,7 @@ export function InputPage() {
               onClick={handleNext}
               disabled={isUploadStepNextDisabled}
             >
-              다음
+              다음: 분석 시작하기
             </Button>
           </ButtonArea>
         </>

--- a/src/pages/InputPage/UploadSection.tsx
+++ b/src/pages/InputPage/UploadSection.tsx
@@ -1,4 +1,7 @@
+import styled from '@emotion/styled';
 import { FileUploader } from '../../components/feature/InputPage/Step3/FileUploader';
+import { OwnerVerifySection } from '../../components/feature/InputPage/Step3/OwnerVerifySection';
+import { UploadAutoDeleteNotice } from '../../components/feature/InputPage/Step3/UploadAutoDeleteNotice';
 import type {
   FileMap,
   UploadedFile,
@@ -10,6 +13,8 @@ interface UploadSectionProps {
   onFilesChange: (key: UploaderKey, files: UploadedFile[]) => void;
   isMaskingConfirmed: boolean;
   onMaskingConfirmChange: (confirmed: boolean) => void;
+  isOwnerVerifyConfirmed: boolean;
+  onOwnerVerifyConfirmChange: (confirmed: boolean) => void;
 }
 
 export function UploadSection({
@@ -17,13 +22,28 @@ export function UploadSection({
   onFilesChange,
   isMaskingConfirmed,
   onMaskingConfirmChange,
+  isOwnerVerifyConfirmed,
+  onOwnerVerifyConfirmChange,
 }: UploadSectionProps) {
   return (
-    <FileUploader
-      files={files}
-      onFilesChange={onFilesChange}
-      isMaskingConfirmed={isMaskingConfirmed}
-      onMaskingConfirmChange={onMaskingConfirmChange}
-    />
+    <Wrap>
+      <FileUploader
+        files={files}
+        onFilesChange={onFilesChange}
+        isMaskingConfirmed={isMaskingConfirmed}
+        onMaskingConfirmChange={onMaskingConfirmChange}
+      />
+      <OwnerVerifySection
+        checked={isOwnerVerifyConfirmed}
+        onChange={onOwnerVerifyConfirmChange}
+      />
+      <UploadAutoDeleteNotice />
+    </Wrap>
   );
 }
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #44
- Closes #45

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 2h
- 실제 작업 시간 : 2h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- `OwnerVerifyBanner.tsx`
  - 경고 아이콘 박스 + 제목·설명 2줄 구조의 소유자 일치 확인 안내 카드 구현
- `OwnerVerifyToggle.tsx`
  - "소유자 일치 확인 완료" 체크박스 토글 구현 (`PrivacyMaskingToggle`과 동일 패턴)
- `OwnerVerifySection.tsx`
  - 배너 + 토글 조합 섹션 컴포넌트
- `PrivacyMaskingBanner.tsx`
  - `OwnerVerifyBanner`와 동일한 `IconBox + Body` 구조로 리팩토링
- `FileUploader.tsx`
  - 마스킹 확인 완료(`isMaskingConfirmed: true`) 시 `PrivacyMaskingBanner` 숨김 처리
- `UploadAutoDeleteNotice.tsx`
  - "업로드된 파일은 분석 후 자동 삭제돼요" 안내 문구 컴포넌트
- `UploadSection.tsx`
  - `OwnerVerifySection`, `UploadAutoDeleteNotice` 추가 및 props 확장
- `InputPage.tsx`
  - `isOwnerVerifyConfirmed` 상태 추가, 버튼 비활성화 조건 확장
  - 새 파일 추가 시 마스킹 토글 자동 리셋
  - "다음: 분석 시작하기" 클릭 시 `/analyze`로 이동

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

- 주요 구현 부분
<img width="415" height="325" alt="주요 구현 부분" src="https://github.com/user-attachments/assets/6e6f7464-fa1c-4505-8a99-4a1b3595bf3e" />

- 시연 영상
<img width="960" height="1302" alt="시연 영상" src="https://github.com/user-attachments/assets/2b05a624-52c4-43c5-94fe-56fed3c9a887" />


<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### PrivacyMaskingBanner 구조 통일

- 문제: 기존 `PrivacyMaskingBanner`는 아이콘을 인라인으로 두고 텍스트를 `pre-line`으로 처리하는 단순한 구조였습니다. `OwnerVerifyBanner`를 새로 만들 때 아이콘 박스(배경색 원형) + 제목/설명 분리 구조로 작성하고 보니, 두 배너가 같은 warning 계열임에도 시각적으로 달랐습니다.
- 해결: `PrivacyMaskingBanner`를 `OwnerVerifyBanner`와 동일하게 `IconBox + Body(h4 + p)` 구조로 리팩토링했습니다.
- 결과: 두 배너가 동일한 레이아웃·타이포그래피 구조를 공유하게 됐습니다.

### 마스킹 확인 완료 시 배너 숨김

- 문제: 기존에는 개인정보 마스킹 배너가 토글을 켜도 계속 표시됐습니다. 이미 확인 완료한 사용자에게 경고 배너를 계속 보여주는 건 불필요한 노이즈였습니다.
- 해결: `FileUploader`에서 `!isMaskingConfirmed` 조건으로 배너를 조건부 렌더링했습니다. 토글은 항상 표시해 on/off 상태를 확인할 수 있게 유지했습니다.
- 결과: 확인 완료 후 배너가 사라지고 토글만 남아 UI가 간결해졌습니다.

### 새 파일 추가 시 마스킹 토글 자동 리셋

- 문제: 파일을 올리고 마스킹을 확인했더라도, 이후 새 파일을 추가하면 추가된 파일은 마스킹 확인이 안 된 상태입니다. 그런데 토글이 켜진 채로 유지되면 확인하지 않은 파일이 있어도 다음으로 넘어갈 수 있는 허점이 생깁니다.
- 해결: `handleFilesChange`에서 파일 수가 늘어날 때(`next.length > prev.length`)만 `isMaskingConfirmed`를 `false`로 리셋했습니다. 삭제나 순서 변경은 이미 확인한 상태를 유지합니다.
- 결과: 새 파일이 추가될 때마다 마스킹 재확인을 강제해 정합성을 보장할 수 있게 됐습니다.


<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- `#92400e` 하드코딩 — `theme.colors`에 `warningText` 토큰 추가 여부 의견 부탁드립니다.
- 마스킹 토글 리셋 조건 (`next.length > prev.length`) — 삭제 시 리셋하지 않는 것이 맞는지 확인 부탁드립니다.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.
