### PR TITLE
[refactor] 결과 페이지 ui 및 파일 구조 변경 및 페이지 적용

### DIFF
--- a/src/components/feature/ResultPage/DetailAnalysis/Contract/ContractAnalysisCard.tsx
+++ b/src/components/feature/ResultPage/DetailAnalysis/Contract/ContractAnalysisCard.tsx
@@ -31,7 +31,7 @@ export function ContractAnalysisCard({
         )
       }
     >
-      <AnalysisIssueList items={previewItems} direction="column" />
+      <AnalysisIssueList items={previewItems} showRowDivider />
     </AnalysisCard>
   );
 }

--- a/src/components/feature/ResultPage/DetailAnalysis/RegistryContract/AnalysisDetailSection.tsx
+++ b/src/components/feature/ResultPage/DetailAnalysis/RegistryContract/AnalysisDetailSection.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useRef, useState, type ReactNode } from 'react';
 import styled from '@emotion/styled';
+
+import { AnalysisCard } from '../../../../common/AnalysisCard';
 import { AnalysisIssueList } from './AnalysisIssueList';
-import type {
-  AnalysisIssueItem,
-  IssueDirection,
-} from '../../../../../types/result';
+import { useIntersectionObserver } from '../../../../../hooks/useIntersectionObserver';
+import type { AnalysisIssueItem } from '../../../../../types/result';
 
 const INITIAL_VISIBLE_COUNT = 5;
 const LOAD_MORE_COUNT = 5;
@@ -13,93 +13,43 @@ interface AnalysisDetailSectionProps {
   title: string;
   icon: ReactNode;
   items: AnalysisIssueItem[];
-  direction?: IssueDirection;
+  showRowDivider?: boolean;
 }
 
 export function AnalysisDetailSection({
   title,
   icon,
   items,
-  direction = 'grid',
+  showRowDivider = false,
 }: AnalysisDetailSectionProps) {
-  const observerRef = useRef<HTMLDivElement | null>(null);
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT);
+  const observerTargetRef = useRef<HTMLDivElement | null>(null);
 
   const visibleItems = items.slice(0, visibleCount);
   const hasMoreItems = visibleCount < items.length;
 
-  useEffect(() => {
-    if (!hasMoreItems) return;
+  const handleIntersect = useCallback(() => {
+    setVisibleCount((prev) => Math.min(prev + LOAD_MORE_COUNT, items.length));
+  }, [items.length]);
 
-    const observerTarget = observerRef.current;
-    if (!observerTarget) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry.isIntersecting) return;
-
-        setVisibleCount((prev) =>
-          Math.min(prev + LOAD_MORE_COUNT, items.length),
-        );
-      },
-      {
-        root: null,
-        rootMargin: '120px',
-        threshold: 0.1,
-      },
-    );
-
-    observer.observe(observerTarget);
-
-    return () => {
-      observer.unobserve(observerTarget);
-    };
-  }, [hasMoreItems, items.length]);
+  useIntersectionObserver({
+    targetRef: observerTargetRef,
+    enabled: hasMoreItems,
+    onIntersect: handleIntersect,
+  });
 
   return (
-    <Page>
-      <Header>
-        <TitleGroup>
-          {icon}
-          <Title>{title}</Title>
-        </TitleGroup>
-      </Header>
-
-      <AnalysisIssueList items={visibleItems} direction={direction} />
+    <AnalysisCard icon={icon} title={title}>
+      <AnalysisIssueList items={visibleItems} showRowDivider={showRowDivider} />
 
       {hasMoreItems && (
-        <ObserverTarget ref={observerRef}>
+        <ObserverTarget ref={observerTargetRef}>
           더 많은 분석 항목을 불러오는 중이에요.
         </ObserverTarget>
       )}
-    </Page>
+    </AnalysisCard>
   );
 }
-
-const Page = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-`;
-
-const Header = styled.header`
-  display: flex;
-  align-items: center;
-`;
-
-const TitleGroup = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-const Title = styled.h1`
-  display: block;
-  font-size: 16px;
-  font-weight: 600;
-  color: ${({ theme }) => theme.colors.text};
-  margin: 0;
-`;
 
 const ObserverTarget = styled.div`
   padding: 16px 0;

--- a/src/components/feature/ResultPage/DetailAnalysis/RegistryContract/AnalysisIssueCard.tsx
+++ b/src/components/feature/ResultPage/DetailAnalysis/RegistryContract/AnalysisIssueCard.tsx
@@ -22,7 +22,7 @@ export function AnalysisIssueCard({
         </IssueTitle>
       </IssueHeader>
 
-      <InfoGrid showRowDivider={showRowDivider}>
+      <InfoGrid>
         {item.details.map((detail, index) => (
           <InfoBox
             key={`${item.id}-${detail.label}`}
@@ -59,7 +59,7 @@ const IssueTitle = styled.p`
   color: ${({ theme }) => theme.colors.text};
 `;
 
-const InfoGrid = styled.div<{ showRowDivider: boolean }>`
+const InfoGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
 `;

--- a/src/components/feature/ResultPage/DetailAnalysis/RegistryContract/AnalysisIssueCard.tsx
+++ b/src/components/feature/ResultPage/DetailAnalysis/RegistryContract/AnalysisIssueCard.tsx
@@ -5,13 +5,13 @@ import type { AnalysisIssueItem } from '../../../../../types/result';
 interface AnalysisIssueCardProps {
   order: number;
   item: AnalysisIssueItem;
-  direction?: 'grid' | 'column';
+  showRowDivider?: boolean;
 }
 
 export function AnalysisIssueCard({
   order,
   item,
-  direction = 'grid',
+  showRowDivider = false,
 }: AnalysisIssueCardProps) {
   return (
     <IssueCard>
@@ -22,12 +22,13 @@ export function AnalysisIssueCard({
         </IssueTitle>
       </IssueHeader>
 
-      <InfoGrid direction={direction}>
+      <InfoGrid showRowDivider={showRowDivider}>
         {item.details.map((detail, index) => (
           <InfoBox
             key={`${item.id}-${detail.label}`}
-            direction={direction}
-            hasDivider={index < item.details.length - 1}
+            isLeftColumn={index % 2 === 0}
+            isTopRow={index < 2}
+            showRowDivider={showRowDivider}
           >
             <InfoLabel>{detail.label}</InfoLabel>
             <InfoText>{detail.content}</InfoText>
@@ -53,47 +54,43 @@ const IssueHeader = styled.div`
 
 const IssueTitle = styled.p`
   margin: 0;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
   color: ${({ theme }) => theme.colors.text};
 `;
 
-const InfoGrid = styled.div<{ direction: 'grid' | 'column' }>`
+const InfoGrid = styled.div<{ showRowDivider: boolean }>`
   display: grid;
-  grid-template-columns: ${({ direction }) =>
-    direction === 'column' ? '1fr' : 'repeat(2, 1fr)'};
+  grid-template-columns: repeat(2, 1fr);
 `;
 
 const InfoBox = styled.div<{
-  direction: 'grid' | 'column';
-  hasDivider: boolean;
+  isLeftColumn: boolean;
+  isTopRow: boolean;
+  showRowDivider: boolean;
 }>`
   display: flex;
   flex-direction: column;
   gap: 6px;
+  padding: 10px;
 
-  ${({ direction, hasDivider, theme }) =>
-    direction === 'grid' &&
-    hasDivider &&
+  ${({ isLeftColumn, theme }) =>
+    isLeftColumn &&
     `
-      padding-right: 14px;
-      margin-right: 14px;
       border-right: 1px solid ${theme.colors.borderLight};
     `}
 
-  ${({ direction, hasDivider, theme }) =>
-    direction === 'column' &&
-    hasDivider &&
+  ${({ isTopRow, showRowDivider, theme }) =>
+    showRowDivider &&
+    isTopRow &&
     `
-      padding-bottom: 14px;
-      margin-bottom: 14px;
       border-bottom: 1px solid ${theme.colors.borderLight};
     `}
 `;
 
 const InfoLabel = styled.p`
   margin: 0;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
 `;
 

--- a/src/components/feature/ResultPage/DetailAnalysis/RegistryContract/AnalysisIssueList.tsx
+++ b/src/components/feature/ResultPage/DetailAnalysis/RegistryContract/AnalysisIssueList.tsx
@@ -4,12 +4,12 @@ import type { AnalysisIssueItem } from '../../../../../types/result';
 
 interface AnalysisIssueListProps {
   items: AnalysisIssueItem[];
-  direction?: 'grid' | 'column';
+  showRowDivider?: boolean;
 }
 
 export function AnalysisIssueList({
   items,
-  direction = 'grid',
+  showRowDivider = false,
 }: AnalysisIssueListProps) {
   return (
     <Content>
@@ -18,7 +18,7 @@ export function AnalysisIssueList({
           key={item.id}
           order={index + 1}
           item={item}
-          direction={direction}
+          showRowDivider={showRowDivider}
         />
       ))}
     </Content>

--- a/src/hooks/useInfiniteAddressScroll.ts
+++ b/src/hooks/useInfiniteAddressScroll.ts
@@ -1,4 +1,5 @@
-import { useEffect, type RefObject } from 'react';
+import type { RefObject } from 'react';
+import { useIntersectionObserver } from './useIntersectionObserver';
 
 interface UseInfiniteAddressScrollParams {
   rootRef: RefObject<HTMLDivElement | null>;
@@ -13,30 +14,10 @@ export function useInfiniteAddressScroll({
   enabled,
   onIntersect,
 }: UseInfiniteAddressScrollParams) {
-  useEffect(() => {
-    if (!enabled) return;
-
-    const target = targetRef.current;
-
-    if (!target) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          onIntersect();
-        }
-      },
-      {
-        root: rootRef.current,
-        rootMargin: '40px',
-        threshold: 0.1,
-      },
-    );
-
-    observer.observe(target);
-
-    return () => {
-      observer.unobserve(target);
-    };
-  }, [enabled, onIntersect, rootRef, targetRef]);
+  useIntersectionObserver({
+    rootRef,
+    targetRef,
+    enabled,
+    onIntersect,
+  });
 }

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+interface UseIntersectionObserverParams {
+  rootRef?: RefObject<Element | null>;
+  targetRef: RefObject<Element | null>;
+  enabled: boolean;
+  onIntersect: () => void;
+  rootMargin?: string;
+  threshold?: number;
+}
+
+export function useIntersectionObserver({
+  rootRef,
+  targetRef,
+  enabled,
+  onIntersect,
+  rootMargin = '120px',
+  threshold = 0.1,
+}: UseIntersectionObserverParams) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const target = targetRef.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        onIntersect();
+      },
+      {
+        root: rootRef?.current ?? null,
+        rootMargin,
+        threshold,
+      },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.unobserve(target);
+    };
+  }, [enabled, onIntersect, rootMargin, rootRef, targetRef, threshold]);
+}

--- a/src/pages/ResultPage/ContractDetailPage.tsx
+++ b/src/pages/ResultPage/ContractDetailPage.tsx
@@ -19,7 +19,7 @@ export function ContractDetailPage({ contract }: ContractDetailPageProps) {
       title="임대차계약서 전체 분석"
       icon={<ScrollText size={22} />}
       items={items}
-      direction="column"
+      showRowDivider
     />
   );
 }

--- a/src/pages/ResultPage/DetailAnalysisSection.tsx
+++ b/src/pages/ResultPage/DetailAnalysisSection.tsx
@@ -1,0 +1,96 @@
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import { JeonseRatioCard } from '../../components/feature/ResultPage/DetailAnalysis/Jeonse/JeonseRatioCard';
+import { RegistryAnalysisCard } from '../../components/feature/ResultPage/DetailAnalysis/Registry/RegistryAnalysisCard';
+import { ContractAnalysisCard } from '../../components/feature/ResultPage/DetailAnalysis/Contract/ContractAnalysisCard';
+import { BuildingInfoCard } from '../../components/feature/ResultPage/DetailAnalysis/Building/BuildingInfoCard';
+import type { ContractData } from '../../types/contract';
+import type { BuildingData } from '../../types/result';
+
+export function DetailAnalysisSection() {
+  const navigate = useNavigate();
+
+  const registryMockData = {
+    trustWarning: true,
+    priorLease: true,
+    mortgageCount: 2,
+    mortgages: [
+      { bank: '국민은행', amount: 120000000 },
+      { bank: '신한은행', amount: 80000000 },
+    ],
+    totalMortgage: 200000000,
+    ownershipChangeRecent: true,
+  };
+
+  const contractMockData: ContractData = {
+    toxicClauses: [
+      {
+        level: 'danger',
+        title: '수리비 전액 임차인 부담',
+        originalText: '수리비는 임차인이 전액 부담한다.',
+        legalIssue: '임차인에게 과도하게 불리한 특약일 수 있습니다.',
+        precedent: '통상적인 노후 및 하자 수선 책임은 임대인에게 있습니다.',
+        suggestion: '수리 범위와 부담 주체를 계약 전에 명확히 협의해 주세요.',
+      },
+      {
+        level: 'danger',
+        title: '중도 해지 불가',
+        originalText: '임차인은 어떠한 경우에도 중도 해지할 수 없다.',
+        legalIssue: '임차인의 계약 해지 권리를 과도하게 제한할 수 있습니다.',
+        precedent: '일방에게 지나치게 불리한 조항은 무효로 판단될 수 있습니다.',
+        suggestion:
+          '중도 해지 조건과 위약금 범위를 명확히 수정하는 것이 좋습니다.',
+      },
+    ],
+    cautionClauses: [
+      {
+        level: 'caution',
+        title: '전세대출 비협조 가능성',
+        originalText: '임대인은 전세대출에 협조하지 않을 수 있다.',
+        legalIssue: '전세대출 진행 과정에서 문제가 발생할 가능성이 있습니다.',
+        precedent: '대출 협조 여부는 계약 전 확인하는 것이 일반적입니다.',
+        suggestion: '임대인의 대출 협조 여부를 특약으로 명시해 주세요.',
+      },
+    ],
+  };
+
+  const buildingMockData: BuildingData = {
+    level: 'safe',
+    primaryUse: '공동주택',
+    isResidential: true,
+    violation: false,
+    approvedDate: '2018-03-12',
+    redevelopmentZone: false,
+  };
+
+  return (
+    <Section>
+      <JeonseRatioCard
+        ratio={82}
+        riskLevel="danger"
+        deposit={200000000}
+        recentPrice={250000000}
+        averagePrice={245000000}
+        lowestPrice={230000000}
+      />
+
+      <RegistryAnalysisCard
+        registry={registryMockData}
+        onClickDetail={() => navigate('/result/registry')}
+      />
+
+      <ContractAnalysisCard
+        contract={contractMockData}
+        onClickDetail={() => navigate('/result/contract')}
+      />
+
+      <BuildingInfoCard building={buildingMockData} />
+    </Section>
+  );
+}
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;

--- a/src/pages/ResultPage/RegistryDetailPage.tsx
+++ b/src/pages/ResultPage/RegistryDetailPage.tsx
@@ -19,7 +19,6 @@ export function RegistryDetailPage({ registry }: RegistryDetailPageProps) {
       title="등기부등본 전체 분석"
       icon={<FileText size={22} />}
       items={items}
-      direction="grid"
     />
   );
 }

--- a/src/pages/ResultPage/ResultPage.tsx
+++ b/src/pages/ResultPage/ResultPage.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import styled from '@emotion/styled';
+
+import { ResultAddressCard } from '../../components/feature/ResultPage/ResultAddressCard';
+import { ResultTabs } from '../../components/feature/ResultPage/ResultTabs';
+import { DetailAnalysisSection } from './DetailAnalysisSection';
+import { ChecklistSection } from './ChecklistSection';
+
+type ResultTab = 'detail' | 'checklist' | 'caution';
+
+export function ResultPage() {
+  const [activeTab, setActiveTab] = useState<ResultTab>('detail');
+
+  return (
+    <Page>
+      <ResultAddressCard address="서울특별시 강남구 테헤란로 123" />
+
+      <ResultTabs activeTab={activeTab} onChangeTab={setActiveTab} />
+
+      {activeTab === 'detail' && <DetailAnalysisSection />}
+      {activeTab === 'checklist' && <ChecklistSection />}
+      {activeTab === 'caution' && <CautionSection />}
+    </Page>
+  );
+}
+
+function CautionSection() {
+  return (
+    <Section>
+      <SectionTitle>주의 사항</SectionTitle>
+      <Description>
+        분석 결과는 참고용 정보입니다. 계약 전 등기부등본, 건축물대장,
+        임대차계약서를 직접 확인하고 필요 시 전문가 상담을 권장해요.
+      </Description>
+    </Section>
+  );
+}
+
+const Page = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const Section = styled.section`
+  padding: 24px 20px;
+  border-radius: ${({ theme }) => theme.radius.xl};
+  background: ${({ theme }) => theme.colors.surface};
+  box-shadow: ${({ theme }) => theme.shadow.card};
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0 0 8px;
+  font-size: 18px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Description = styled.p`
+  margin: 0;
+  color: ${({ theme }) => theme.colors.textSub};
+  font-size: 14px;
+  line-height: 1.6;
+`;

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -1,12 +1,56 @@
 import { Routes, Route, useNavigate } from 'react-router-dom';
 import { House, ChevronLeft } from 'lucide-react';
-import { InputPage } from '../pages/InputPage/InputPage';
+
 import { LandingPage } from '../pages/LandingPage/LandingPage';
+import { InputPage } from '../pages/InputPage/InputPage';
 import { AnalysisLoadingPage } from '../pages/AnalyzingPage/AnalysisLoadingPage';
+import { ResultPage } from '../pages/ResultPage/ResultPage';
+import { RegistryDetailPage } from '../pages/ResultPage/RegistryDetailPage';
+import { ContractDetailPage } from '../pages/ResultPage/ContractDetailPage';
+
 import { Layout } from '../layout/Layout';
 import { Header } from '../components/common/Header';
 import { StepIndicator } from '../components/common/StepIndicator';
 import { Button } from '../components/common/Button';
+
+const registryMockData = {
+  trustWarning: true,
+  priorLease: true,
+  mortgageCount: 2,
+  mortgages: [
+    { bank: '국민은행', amount: 120000000 },
+    { bank: '신한은행', amount: 80000000 },
+  ],
+  totalMortgage: 200000000,
+  ownershipChangeRecent: true,
+};
+
+const contractMockData = {
+  toxicClauses: [
+    {
+      level: 'danger' as const,
+      title: '수리비 전액 임차인 부담',
+      originalText: '수리비는 임차인이 전액 부담한다.',
+      legalIssue:
+        '임차인에게 과도하게 불리한 특약으로 해석될 가능성이 있습니다.',
+      precedent: '통상적인 노후 및 하자 수선 책임은 임대인에게 있습니다.',
+      suggestion:
+        '수리 범위와 부담 주체를 계약 전에 명확히 협의하는 것이 좋습니다.',
+    },
+  ],
+  cautionClauses: [
+    {
+      level: 'caution' as const,
+      title: '전세대출 비협조 가능성',
+      originalText: '임대인은 전세대출에 협조하지 않을 수 있다.',
+      legalIssue: '전세대출 진행 과정에서 문제가 발생할 가능성이 있습니다.',
+      precedent:
+        '대출 협조 여부는 계약 체결 전 반드시 확인하는 것이 일반적입니다.',
+      suggestion:
+        '임대인의 대출 협조 여부를 특약으로 명시하는 것을 권장합니다.',
+    },
+  ],
+};
 
 export function AppRouter() {
   const navigate = useNavigate();
@@ -38,6 +82,7 @@ export function AppRouter() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/analyze" element={<AnalysisLoadingPage />} />
       </Route>
+
       <Route
         element={
           <Layout
@@ -62,7 +107,38 @@ export function AppRouter() {
       >
         <Route path="/input" element={<InputPage />} />
       </Route>
-      {/* <Route path="*" element={<404페이지 />} /> */}
+
+      <Route
+        element={
+          <Layout
+            header={
+              <Header
+                title="분석 결과"
+                left={
+                  <Button
+                    variant="ghost"
+                    tone="black"
+                    size="md"
+                    iconStart={<ChevronLeft />}
+                    aria-label="이전"
+                    onClick={() => navigate(-1)}
+                  />
+                }
+              />
+            }
+          />
+        }
+      >
+        <Route path="/result" element={<ResultPage />} />
+        <Route
+          path="/result/registry"
+          element={<RegistryDetailPage registry={registryMockData} />}
+        />
+        <Route
+          path="/result/contract"
+          element={<ContractDetailPage contract={contractMockData} />}
+        />
+      </Route>
     </Routes>
   );
 }

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,7 +1,9 @@
 // export type IssueVariant = 'danger' | 'warning' | 'success';
 
-export type IssueVariant = 'danger' | 'caution' | 'safe'; //백엔드 json 구조
-export type IssueDirection = 'grid' | 'column';
+//export type IssueVariant = 'danger' | 'caution' | 'safe'; //백엔드 json 구조
+
+import type { TagVariant } from '../constants/tag';
+
 export interface AnalysisIssueDetail {
   label: string;
   content: string;
@@ -11,14 +13,14 @@ export interface AnalysisIssueItem {
   id: string;
   title: string;
   label: string;
-  variant: IssueVariant;
+  variant: TagVariant;
   details: AnalysisIssueDetail[];
 }
 
-export type BuildingLevel = 'danger' | 'caution' | 'safe';
+//export type BuildingLevel = 'danger' | 'caution' | 'safe';
 
 export interface BuildingData {
-  level: BuildingLevel;
+  level: TagVariant;
   primaryUse: string;
   isResidential: boolean;
   violation: boolean;


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #51

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1.5h
- 실제 작업 시간 : 1.5h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

- 결과 페이지(ResultPage)에 상세 분석 섹션 및 체크리스트 섹션 적용
- ResultTabs를 활용하여 상세 분석 / 체크리스트 탭 전환 구현
- 라우팅 추가
- 임대차계약서 분석 카드 UI를 2x2 grid 구조로 개선
- 임대차계약서 분석 상세 페이지에만 row divider 적용되도록 분리
- 상세 분석 페이지를 AnalysisCard 내부 구조로 리팩토링하여 카드 UI 일관성 개선
- IntersectionObserver 기반 무한스크롤 공통 로직 분리
- useIntersectionObserver 훅 추가
- 주소 검색 무한스크롤은 useInfiniteAddressScroll 래퍼 훅 구조 유지

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- AddressSearchResult와 AnalysisDetailSection 모두 무한스크롤 구조를 사용하고 있어 공통화 여부를 고민했습니다.
  - 주소 검색은 백엔드에서 페이지 단위로 데이터를 추가 요청하는 구조이고,
  - 분석 상세 페이지는 이미 받은 데이터를 프론트에서 slice 하여 추가 노출하는 구조라 완전히 동일한 훅으로 추상화하기에는 역할 차이가 있다고 판단했습니다.
  - 따라서 IntersectionObserver 감지 로직만 useIntersectionObserver로 공통화하고,
  - 주소 검색은 useInfiniteAddressScroll,
  - 분석 상세 페이지는 useIntersectionObserver를 직접 사용하는 방향으로 분리했습니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- 아직 api 연동 전이라 App.tsx와 DetailAnalysisSection.tsx에 mock 데이터가 남아있습니다. api 연동할 때 해당 mock 데이터 지우도록 하겠습니다. 

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 분석 결과 페이지 신규 추가로 부동산 정보를 체계적으로 제공
  * 지역 계약금 비율, 레지스트리 분석, 계약 분석 등 상세 분석 정보를 한눈에 확인 가능

* **Refactor**
  * 분석 카드 레이아웃 및 구성요소 최적화를 통해 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->