### PR TITLE
[feat] /analysis/init API 연동 (#82)

### DIFF
--- a/src/api/analyzing.ts
+++ b/src/api/analyzing.ts
@@ -1,4 +1,43 @@
+import { apiClient } from './client';
 import { BASE_URL } from './config';
+import type { ContractType } from '../constants/contract';
+
+interface ContractPeriod {
+  startDate: string;
+  endDate: string;
+}
+
+interface InitAnalysisRequest {
+  address: string;
+  jibunAddress: string;
+  admCd: string;
+  rnMgtSn: string;
+  bdMgtSn: string;
+  mno: string;
+  sno: string;
+  deposit: number;
+  monthlyRent: number;
+  contractType: ContractType;
+  contractPeriod: ContractPeriod;
+}
+
+interface InitAnalysisResponse {
+  status: 'success';
+  data: {
+    sessionId: string;
+  };
+}
+
+export async function initAnalysis(
+  request: InitAnalysisRequest,
+): Promise<string> {
+  const { data } = await apiClient.post<InitAnalysisResponse>(
+    '/analysis/init',
+    request,
+  );
+
+  return data.data.sessionId;
+}
 
 export function createAnalysisStream(sessionId: string) {
   const encodedSessionId = encodeURIComponent(sessionId);

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -98,4 +98,14 @@ const StyledInput = styled.input<{ $hasStart: boolean; $hasEnd: boolean }>`
     opacity: 0.5;
     cursor: not-allowed;
   }
+
+  &[type='number']::-webkit-inner-spin-button,
+  &[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+  }
+
+  &[type='number'] {
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
 `;

--- a/src/pages/InputPage/ContractSection.tsx
+++ b/src/pages/InputPage/ContractSection.tsx
@@ -8,10 +8,10 @@ import type { ContractType } from '../../constants/contract';
 interface ContractSectionProps {
   contractType: ContractType;
   onContractTypeChange: (contractType: ContractType) => void;
-  deposit: string;
-  onDepositChange: (deposit: string) => void;
-  monthlyRent: string;
-  onMonthlyRentChange: (monthlyRent: string) => void;
+  deposit: number;
+  onDepositChange: (deposit: number) => void;
+  monthlyRent: number;
+  onMonthlyRentChange: (monthlyRent: number) => void;
   startDate: Date | null;
   onStartDateChange: (date: Date | null) => void;
   endDate: Date | null;
@@ -55,12 +55,12 @@ export function ContractSection({
         <Label htmlFor="deposit">보증금</Label>
         <Input
           id="deposit"
-          value={deposit}
-          onChange={(event) => onDepositChange(event.target.value)}
-          inputMode="numeric"
+          value={deposit || ''}
+          onChange={(event) => onDepositChange(event.target.valueAsNumber)}
+          type="number"
           placeholder="보증금을 입력해주세요"
           start={<span>₩</span>}
-          end={<span>원</span>}
+          end={<span>만원</span>}
         />
       </FieldGroup>
 
@@ -69,12 +69,14 @@ export function ContractSection({
           <Label htmlFor="monthlyRent">월세</Label>
           <Input
             id="monthlyRent"
-            value={monthlyRent}
-            onChange={(event) => onMonthlyRentChange(event.target.value)}
-            inputMode="numeric"
+            value={monthlyRent || ''}
+            onChange={(event) =>
+              onMonthlyRentChange(event.target.valueAsNumber)
+            }
+            type="number"
             placeholder="월세를 입력해주세요"
             start={<span>₩</span>}
-            end={<span>원</span>}
+            end={<span>만원</span>}
           />
         </FieldGroup>
       )}

--- a/src/pages/InputPage/ContractSection.tsx
+++ b/src/pages/InputPage/ContractSection.tsx
@@ -10,6 +10,8 @@ interface ContractSectionProps {
   onContractTypeChange: (contractType: ContractType) => void;
   deposit: string;
   onDepositChange: (deposit: string) => void;
+  monthlyRent: string;
+  onMonthlyRentChange: (monthlyRent: string) => void;
   startDate: Date | null;
   onStartDateChange: (date: Date | null) => void;
   endDate: Date | null;
@@ -21,11 +23,14 @@ export function ContractSection({
   onContractTypeChange,
   deposit,
   onDepositChange,
+  monthlyRent,
+  onMonthlyRentChange,
   startDate,
   onStartDateChange,
   endDate,
   onEndDateChange,
 }: ContractSectionProps) {
+  const hasMonthlyRent = contractType !== 'jeonse';
   const handleStartDateChange = (date: Date | null) => {
     onStartDateChange(date);
 
@@ -58,6 +63,21 @@ export function ContractSection({
           end={<span>원</span>}
         />
       </FieldGroup>
+
+      {hasMonthlyRent && (
+        <FieldGroup>
+          <Label htmlFor="monthlyRent">월세</Label>
+          <Input
+            id="monthlyRent"
+            value={monthlyRent}
+            onChange={(event) => onMonthlyRentChange(event.target.value)}
+            inputMode="numeric"
+            placeholder="월세를 입력해주세요"
+            start={<span>₩</span>}
+            end={<span>원</span>}
+          />
+        </FieldGroup>
+      )}
 
       <FieldGroup>
         <Label>계약일</Label>

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -12,6 +12,8 @@ import type {
   UploadedFile,
   UploaderKey,
 } from '../../constants/uploadedFile';
+import { initAnalysis } from '../../api/analyzing';
+import { getApiErrorMessage, type ApiError } from '../../api/error';
 
 const INPUT_STEPS = ['address', 'contract', 'upload'] as const;
 
@@ -27,12 +29,20 @@ const INITIAL_ORDER_CONFIRMED: OrderConfirmMap = {
   contract: false,
 };
 
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export function InputPage() {
   const navigate = useNavigate();
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [selectedAddress, setSelectedAddress] = useState<Address | null>(null);
   const [contractType, setContractType] = useState<ContractType>('jeonse');
   const [deposit, setDeposit] = useState('');
+  const [monthlyRent, setMonthlyRent] = useState('');
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [endDate, setEndDate] = useState<Date | null>(null);
   const [files, setFiles] = useState<FileMap>(INITIAL_FILES);
@@ -41,6 +51,9 @@ export function InputPage() {
   const [orderConfirmed, setOrderConfirmed] = useState<OrderConfirmMap>(
     INITIAL_ORDER_CONFIRMED,
   );
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
 
   const currentStep = INPUT_STEPS[currentStepIndex];
 
@@ -55,16 +68,56 @@ export function InputPage() {
   const isOrderConfirmed = Object.entries(orderConfirmed).every(
     ([key, confirmed]) => files[key as UploaderKey].length <= 1 || confirmed,
   );
+  const isContractStepNextDisabled = isSubmitting;
+
   const isUploadStepNextDisabled =
+    !sessionId ||
     (hasWarningFiles && !isMaskingConfirmed) ||
     !isOwnerVerifyConfirmed ||
     (hasMultiPageFiles && !isOrderConfirmed);
 
-  const handleNext = () => {
-    if (currentStep === 'upload') {
-      navigate('/analyze');
-      return;
+  const handleContractNext = async () => {
+    if (!selectedAddress || !startDate || !endDate) return;
+
+    setIsSubmitting(true);
+    setSubmitError('');
+
+    try {
+      const id = await initAnalysis({
+        address: selectedAddress.roadAddress,
+        jibunAddress: selectedAddress.jibunAddress,
+        admCd: selectedAddress.admCd,
+        rnMgtSn: selectedAddress.rnMgtSn,
+        bdMgtSn: selectedAddress.bdMgtSn,
+        mno: selectedAddress.mno,
+        sno: selectedAddress.sno,
+        deposit: Number(deposit.replace(/[^0-9]/g, '')),
+        monthlyRent:
+          contractType !== 'jeonse'
+            ? Number(monthlyRent.replace(/[^0-9]/g, ''))
+            : 0,
+        contractType,
+        contractPeriod: {
+          startDate: formatDate(startDate),
+          endDate: formatDate(endDate),
+        },
+      });
+
+      setSessionId(id);
+      setCurrentStepIndex((prev) => Math.min(prev + 1, INPUT_STEPS.length - 1));
+    } catch (error) {
+      setSubmitError(getApiErrorMessage(error as ApiError));
+    } finally {
+      setIsSubmitting(false);
     }
+  };
+
+  const handleUploadNext = () => {
+    if (!sessionId) return;
+    navigate('/analyze', { state: { sessionId } });
+  };
+
+  const handleNext = () => {
     setCurrentStepIndex((prev) => Math.min(prev + 1, INPUT_STEPS.length - 1));
   };
 
@@ -111,11 +164,15 @@ export function InputPage() {
             onContractTypeChange={setContractType}
             deposit={deposit}
             onDepositChange={setDeposit}
+            monthlyRent={monthlyRent}
+            onMonthlyRentChange={setMonthlyRent}
             startDate={startDate}
             onStartDateChange={setStartDate}
             endDate={endDate}
             onEndDateChange={setEndDate}
           />
+
+          {submitError && <ErrorText>{submitError}</ErrorText>}
 
           <ButtonArea>
             <Button
@@ -131,9 +188,10 @@ export function InputPage() {
               variant="primary"
               size="lg"
               width="100%"
-              onClick={handleNext}
+              onClick={handleContractNext}
+              disabled={isContractStepNextDisabled}
             >
-              다음
+              {isSubmitting ? '준비 중...' : '다음'}
             </Button>
           </ButtonArea>
         </>
@@ -165,7 +223,7 @@ export function InputPage() {
               variant="primary"
               size="lg"
               width="100%"
-              onClick={handleNext}
+              onClick={handleUploadNext}
               disabled={isUploadStepNextDisabled}
             >
               다음: 분석 시작하기
@@ -188,4 +246,10 @@ const ButtonArea = styled.div`
   display: flex;
   gap: 8px;
   padding-top: 24px;
+`;
+
+const ErrorText = styled.p`
+  font-size: 13px;
+  color: ${({ theme }) => theme.colors.danger};
+  text-align: center;
 `;

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -41,8 +41,8 @@ export function InputPage() {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [selectedAddress, setSelectedAddress] = useState<Address | null>(null);
   const [contractType, setContractType] = useState<ContractType>('jeonse');
-  const [deposit, setDeposit] = useState('');
-  const [monthlyRent, setMonthlyRent] = useState('');
+  const [deposit, setDeposit] = useState(0);
+  const [monthlyRent, setMonthlyRent] = useState(0);
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [endDate, setEndDate] = useState<Date | null>(null);
   const [files, setFiles] = useState<FileMap>(INITIAL_FILES);
@@ -91,11 +91,8 @@ export function InputPage() {
         bdMgtSn: selectedAddress.bdMgtSn,
         mno: selectedAddress.mno,
         sno: selectedAddress.sno,
-        deposit: Number(deposit.replace(/[^0-9]/g, '')),
-        monthlyRent:
-          contractType !== 'jeonse'
-            ? Number(monthlyRent.replace(/[^0-9]/g, ''))
-            : 0,
+        deposit: deposit * 10000,
+        monthlyRent: contractType !== 'jeonse' ? monthlyRent * 10000 : 0,
         contractType,
         contractPeriod: {
           startDate: formatDate(startDate),


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #82 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

### 간단 요약
- 계약 스텝 다음 버튼 클릭 시 `/analysis/init` API를 호출해 분석 세션을 초기화
- 응답받은 `sessionId`를 파일 업로드 페이지를 거쳐 분석 중 페이지로 전달
- 보증금·월세 입력값을 `string` → `number` 타입으로 변경하고 만원 단위로 입력받아 API 전송 시 원 단위로 변환
- `Input` 공통 컴포넌트 `type="number"` 스핀 버튼(▲▼) 제거

### 설명
- `src/api/analyzing.ts`
  - `InitAnalysisRequest` 인터페이스 정의 (address, jibunAddress, admCd, rnMgtSn, bdMgtSn, mno, sno, deposit, monthlyRent, contractType, contractPeriod)
  - `initAnalysis()` 함수 구현 (POST `/analysis/init`, 응답에서 sessionId 반환)
- `src/components/common/Input.tsx`
  - `type="number"` 스핀 버튼(▲▼) 전역 제거
- `src/pages/InputPage/ContractSection.tsx`
  - `monthlyRent` / `onMonthlyRentChange` props 추가 (타입 `number`)
  - `jeonse` 이외 계약 유형 선택 시 월세 입력 필드 조건부 노출
  - 보증금·월세 입력 단위를 만원으로 변경 (`end="만원"`)
  - `deposit`, `monthlyRent` props 타입 `string` → `number`, `type="number"` + `valueAsNumber`로 변환 로직 제거
- `src/pages/InputPage/InputPage.tsx`
  - `deposit`, `monthlyRent` state 타입 `string` → `number`
  - `sessionId` state 추가
  - 계약 스텝 다음 버튼 → `handleContractNext` (initAnalysis 호출, sessionId 저장, 업로드 스텝 이동)
  - 업로드 스텝 다음 버튼 → `handleUploadNext` (sessionId를 state로 `/analyze`에 전달)
  - API 호출 중 버튼 비활성화, 에러 시 인라인 메시지 표시


<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### /analysis/init 호출 시점 — 핸들러 분리

- 문제: 기존 `handleNext` 하나가 세 스텝(address/contract/upload)을 모두 처리하는 구조였습니다. upload 스텝 진입 버튼과 init 호출 시점이 뒤섞일 여지가 있었고, 실제로 초기 구현에서 upload 스텝에서 init을 호출하는 실수가 있었습니다.
- 해결: API 명세서 기준("STEP1 [다음] 버튼 클릭 시 호출")을 재확인하고, `handleNext`(address 스텝), `handleContractNext`(contract 스텝, init 호출), `handleUploadNext`(upload 스텝, navigate) 세 핸들러로 분리했습니다.
- 결과: 각 스텝 버튼이 독립적인 핸들러를 가져 책임이 명확해지고, init 실패 시 에러가 contract 스텝에서만 노출됩니다.

### 보증금·월세 입력 단위

- 문제: `type="number"`로 변경 후 보증금을 원 단위로 입력하면 `300000000`처럼 0이 8개 붙어 사용성이 나쁩니다. 실제 전세 보증금은 최소 수천만 원 단위라 원 단위 직접 입력은 오입력 가능성도 높습니다.
- 해결: 입력 단위를 만원으로 변경하고(`end="만원"`), API 전송 시 `* 10000`을 적용해 원 단위로 변환했습니다.
- 결과: `3000` 입력 → 화면에 `₩ 3000 만원` 표시 → API에는 `30000000` 전송으로 입력 편의성과 API 스펙을 동시에 만족합니다.

### sessionId 관리 방식

- 문제: init 응답 sessionId를 어디에 저장할지 결정이 필요했습니다. 이슈 81 코드리뷰에서 "새로고침 시 초기화 안내만 제공, Zustand 불필요"로 결론이 났지만 sessionId는 upload 스텝과 `/analyze` 페이지 두 곳에서 필요합니다.
- 해결: `InputPage` 부모 state로 `sessionId`를 들고 있다가 `/analyze`로 navigate 시 `location.state`로 전달하는 기존 패턴을 유지했습니다. sessionStorage 저장은 `AnalysisLoadingPage`에서 분석 완료 시점에 처리하는 기존 흐름을 변경하지 않았습니다.
- 결과: 기존 아키텍처를 최소한으로 변경하면서 데이터 흐름이 단방향으로 유지됩니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- `deposit`, `monthlyRent`를 만원 단위로 입력받아 `* 10000`으로 변환하는 방식이 API 스펙과 잘 맞는지

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 월세 입력 필드 추가
  * 계약 정보 입력 시 분석 세션 자동 시작

* **개선사항**
  * 숫자 입력 필드의 브라우저 기본 UI 제거로 입력 환경 개선
  * 입력 오류 시 인라인 에러 메시지 표시

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/S1J2-Lab/home-protect-client/pull/94)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->