### PR TITLE
[feat] /documents/ocr/registry, /documents/ocr/contract API 연동 및 에러 UI 개선 (#83)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^1.12.0",
+    "pdf-lib": "^1.17.1",
     "react": "^19.2.4",
     "react-datepicker": "^9.1.0",
     "react-dom": "^19.2.4",

--- a/src/api/documentApi.ts
+++ b/src/api/documentApi.ts
@@ -1,0 +1,41 @@
+import { apiClient } from './client';
+
+interface OcrRegistryResponse {
+  status: 'success';
+  data: {
+    registrySessionId: string;
+    safe: boolean;
+  };
+}
+
+interface OcrContractResponse {
+  status: 'success';
+  data: {
+    contractSessionId: string;
+    safe: boolean;
+  };
+}
+
+export async function scanRegistry(file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const { data } = await apiClient.post<OcrRegistryResponse>(
+    '/documents/ocr/registry',
+    formData,
+  );
+
+  return data.data;
+}
+
+export async function scanContract(file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const { data } = await apiClient.post<OcrContractResponse>(
+    '/documents/ocr/contract',
+    formData,
+  );
+
+  return data.data;
+}

--- a/src/components/feature/InputPage/Step3/FileItemCard.tsx
+++ b/src/components/feature/InputPage/Step3/FileItemCard.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled';
-import { Check, Trash2, TriangleAlert, CircleAlert } from 'lucide-react';
-import { useState } from 'react';
+import { Check, Trash2, Loader, XCircle } from 'lucide-react';
 import { Tag } from '../../../common/Tag';
 import { Button } from '../../../common/Button';
-import type { UploadedFile } from '../../../../constants/uploadedFile';
+import type {
+  UploadedFile,
+  FileStatus,
+} from '../../../../constants/uploadedFile';
 
 const ICON_STROKE_WIDTH = 2.2;
 const STATUS_ICON_SIZE = 18;
@@ -25,28 +27,31 @@ export function FileItemCard({
   name,
   size,
   status,
-  issues,
   onRemove,
   dragHandle,
 }: FileItemCardProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  const handleToggleExpand = () => setIsExpanded((prev) => !prev);
-
   return (
     <ItemWrap $status={status}>
       <Row>
         {dragHandle}
 
         <StatusIconBox $status={status}>
-          {status === 'ok' ? (
+          {status === 'safe' && (
             <Check
               size={STATUS_ICON_SIZE}
               strokeWidth={ICON_STROKE_WIDTH}
               aria-hidden="true"
             />
-          ) : (
-            <TriangleAlert
+          )}
+          {status === 'loading' && (
+            <Loader
+              size={STATUS_ICON_SIZE}
+              strokeWidth={ICON_STROKE_WIDTH}
+              aria-hidden="true"
+            />
+          )}
+          {(status === 'error' || status === 'pending') && (
+            <XCircle
               size={STATUS_ICON_SIZE}
               strokeWidth={ICON_STROKE_WIDTH}
               aria-hidden="true"
@@ -57,30 +62,16 @@ export function FileItemCard({
         <Meta>
           <FileName>{name}</FileName>
           <SubRow>
-            {status === 'ok' ? (
-              <Tag variant="safe">정상</Tag>
-            ) : (
-              <WarningBadge variant="danger">주의 필요</WarningBadge>
-            )}
+            {status === 'safe' && <Tag variant="safe">정상</Tag>}
+            {status === 'loading' && <Tag variant="primary">분석 중</Tag>}
+            {status === 'error' && <Tag variant="danger">재업로드 필요</Tag>}
+            {status === 'pending' && <Tag variant="caution">대기 중</Tag>}
             <Separator>·</Separator>
             <FileSize>{formatSize(size)}</FileSize>
           </SubRow>
         </Meta>
 
         <Actions>
-          {status === 'warning' && (
-            <AlertButton
-              type="button"
-              aria-label="문제 항목 보기"
-              onClick={handleToggleExpand}
-            >
-              <CircleAlert
-                size={ACTION_ICON_SIZE}
-                strokeWidth={ICON_STROKE_WIDTH}
-                aria-hidden="true"
-              />
-            </AlertButton>
-          )}
           <Button
             variant="ghost"
             tone="black"
@@ -97,41 +88,14 @@ export function FileItemCard({
           />
         </Actions>
       </Row>
-
-      {isExpanded && status === 'warning' && <FileIssuePanel issues={issues} />}
     </ItemWrap>
   );
 }
 
-interface FileIssuePanelProps {
-  issues: string[];
-}
-
-function FileIssuePanel({ issues }: FileIssuePanelProps) {
-  return (
-    <IssuePanel>
-      <IssueTitle>
-        <TriangleAlert
-          size={12}
-          strokeWidth={ICON_STROKE_WIDTH}
-          aria-hidden="true"
-        />
-        마스킹이 필요한 항목
-      </IssueTitle>
-      {issues.map((issue) => (
-        <IssueItem key={issue}>{issue}</IssueItem>
-      ))}
-    </IssuePanel>
-  );
-}
-
-const ItemWrap = styled.div<{ $status: 'ok' | 'warning' }>`
+const ItemWrap = styled.div<{ $status: FileStatus }>`
   border-radius: ${({ theme }) => theme.radius.md};
-  border: 1px solid
-    ${({ theme, $status }) =>
-      $status === 'warning' ? theme.colors.dangerLight : theme.colors.border};
-  background: ${({ theme, $status }) =>
-    $status === 'warning' ? theme.colors.dangerBg : theme.colors.surface};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.surface};
   overflow: hidden;
   transition:
     border-color 0.15s,
@@ -145,14 +109,14 @@ const Row = styled.div`
   padding: 12px;
 `;
 
-const StatusIconBox = styled.div<{ $status: 'ok' | 'warning' }>`
+const StatusIconBox = styled.div<{ $status: FileStatus }>`
   width: 36px;
   height: 36px;
   border-radius: ${({ theme }) => theme.radius.sm};
   background: ${({ theme, $status }) =>
-    $status === 'warning' ? theme.colors.dangerLight : theme.colors.successBg};
+    $status === 'safe' ? theme.colors.successBg : theme.colors.primaryLight};
   color: ${({ theme, $status }) =>
-    $status === 'warning' ? theme.colors.danger : theme.colors.success};
+    $status === 'safe' ? theme.colors.success : theme.colors.primary};
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -180,10 +144,6 @@ const SubRow = styled.div`
   gap: 6px;
 `;
 
-const WarningBadge = styled(Tag)`
-  background: ${({ theme }) => theme.colors.dangerLight};
-`;
-
 const Separator = styled.span`
   font-size: 11px;
   color: ${({ theme }) => theme.colors.textMuted};
@@ -198,57 +158,4 @@ const Actions = styled.div`
   display: flex;
   align-items: center;
   gap: 2px;
-`;
-
-const AlertButton = styled.button`
-  width: 28px;
-  height: 28px;
-  border-radius: ${({ theme }) => theme.radius.sm};
-  background: transparent;
-  color: ${({ theme }) => theme.colors.danger};
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.15s;
-
-  &:hover:not(:disabled),
-  &:active:not(:disabled) {
-    background: ${({ theme }) => theme.colors.dangerBg};
-  }
-`;
-
-const IssuePanel = styled.div`
-  border-top: 1px dashed ${({ theme }) => theme.colors.dangerLight};
-  background: ${({ theme }) => theme.colors.surface};
-  padding: 12px 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-`;
-
-const IssueTitle = styled.p`
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  font-weight: 800;
-  color: ${({ theme }) => theme.colors.danger};
-  margin-bottom: 2px;
-`;
-
-const IssueItem = styled.p`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  color: ${({ theme }) => theme.colors.textSub};
-
-  &::before {
-    content: '';
-    width: 5px;
-    height: 5px;
-    border-radius: ${({ theme }) => theme.radius.full};
-    background: ${({ theme }) => theme.colors.danger};
-    flex-shrink: 0;
-  }
 `;

--- a/src/components/feature/InputPage/Step3/FileUploader.tsx
+++ b/src/components/feature/InputPage/Step3/FileUploader.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import { FileUploaderCard } from './FileUploaderCard';
-import { PrivacyMaskingBanner } from './PrivacyMaskingBanner';
 import { PrivacyMaskingToggle } from './PrivacyMaskingToggle';
 import type {
   FileMap,
@@ -15,12 +14,7 @@ interface FileUploaderProps {
   files: FileMap;
   onFilesChange: (key: UploaderKey, files: UploadedFile[]) => void;
   onOrderConfirmChange: (key: UploaderKey, confirmed: boolean) => void;
-}
-
-function hasWarningFiles(files: FileMap) {
-  return Object.values(files).some((list) =>
-    list.some((f) => f.status === 'warning'),
-  );
+  onScanSuccess: (key: UploaderKey, sessionId: string) => void;
 }
 
 export function FileUploader({
@@ -29,9 +23,8 @@ export function FileUploader({
   files,
   onFilesChange,
   onOrderConfirmChange,
+  onScanSuccess,
 }: FileUploaderProps) {
-  const showMaskingSection = hasWarningFiles(files);
-
   return (
     <Wrap>
       {UPLOADER_CONFIGS.map((config) => (
@@ -43,18 +36,14 @@ export function FileUploader({
           onOrderConfirmChange={(confirmed) =>
             onOrderConfirmChange(config.key, confirmed)
           }
+          onScanSuccess={onScanSuccess}
         />
       ))}
 
-      {showMaskingSection && (
-        <MaskingSection>
-          {!isMaskingConfirmed && <PrivacyMaskingBanner />}
-          <PrivacyMaskingToggle
-            checked={isMaskingConfirmed}
-            onChange={onMaskingConfirmChange}
-          />
-        </MaskingSection>
-      )}
+      <PrivacyMaskingToggle
+        checked={isMaskingConfirmed}
+        onChange={onMaskingConfirmChange}
+      />
     </Wrap>
   );
 }
@@ -63,10 +52,4 @@ const Wrap = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px;
-`;
-
-const MaskingSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
 `;

--- a/src/components/feature/InputPage/Step3/FileUploaderCard.tsx
+++ b/src/components/feature/InputPage/Step3/FileUploaderCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useState, useRef } from 'react';
-import { Check, Lock } from 'lucide-react';
+import { Check, Lock, CircleAlert, TriangleAlert } from 'lucide-react';
 import { Card } from '../../../common/Card';
 import { Button } from '../../../common/Button';
 import { UploaderCardHeader } from './UploaderCardHeader';
@@ -10,32 +10,41 @@ import { UploaderFileList } from './UploaderFileList';
 import type {
   UploadedFile,
   UploaderConfig,
+  UploaderKey,
 } from '../../../../constants/uploadedFile';
-import { PRIVACY_ISSUE_KEYS } from '../../../../constants/uploadedFile';
+import { scanRegistry, scanContract } from '../../../../api/documentApi';
+import { mergeFilesToPdf } from '../../../../utils/mergeFilesToPdf';
+import { type ApiError } from '../../../../api/error';
+import {
+  saveRegistrySessionId,
+  saveContractSessionId,
+} from '../../../../utils/analysisStorage';
 
 const CONFIRM_ICON_SIZE = 14;
 const CONFIRM_ICON_STROKE = 2.5;
+const ALERT_ICON_SIZE = 15;
+const ALERT_ICON_STROKE = 2.2;
 
 interface FileUploaderCardProps {
   config: UploaderConfig;
   files: UploadedFile[];
   onChange: (files: UploadedFile[]) => void;
   onOrderConfirmChange: (confirmed: boolean) => void;
+  onScanSuccess: (key: UploaderKey, sessionId: string) => void;
 }
 
-function inspectFile(name: string): Pick<UploadedFile, 'status' | 'issues'> {
-  const looksUnmasked = /원본|raw|unmask|개인/.test(name);
-  const flagged = name.length % 3 === 0;
-  if (looksUnmasked || flagged) {
-    const issues = PRIVACY_ISSUE_KEYS.filter(
-      (_, i) => (name.length + i) % 2 === 0,
-    ).slice(0, 3);
-    return {
-      status: 'warning',
-      issues: issues.length ? [...issues] : ['주민등록번호 일부 노출'],
-    };
+type ScanError =
+  | { code: 'PII_DETECTED'; message: string; nonMasked: string[] }
+  | { code: 'OCR_FAILED'; message: string }
+  | { code: string; message: string };
+
+async function scanDocument(key: UploaderKey, file: File) {
+  if (key === 'registry') {
+    const result = await scanRegistry(file);
+    return result.registrySessionId;
   }
-  return { status: 'ok', issues: [] };
+  const result = await scanContract(file);
+  return result.contractSessionId;
 }
 
 export function FileUploaderCard({
@@ -43,46 +52,91 @@ export function FileUploaderCard({
   files,
   onChange,
   onOrderConfirmChange,
+  onScanSuccess,
 }: FileUploaderCardProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [isOrderConfirmed, setIsOrderConfirmed] = useState(false);
+  const [isScanning, setIsScanning] = useState(false);
+  const [scanError, setScanError] = useState<ScanError | null>(null);
+  const [isErrorExpanded, setIsErrorExpanded] = useState(false);
 
   const openPicker = () => inputRef.current?.click();
 
-  const resetOrderConfirm = () => {
+  const resetConfirm = () => {
     setIsOrderConfirmed(false);
     onOrderConfirmChange(false);
+    setScanError(null);
+    setIsErrorExpanded(false);
   };
 
   const handleFiles = (list: FileList | null) => {
     if (!list || !list.length) return;
     const next: UploadedFile[] = Array.from(list).map((f, i) => ({
       id: `${Date.now()}-${i}-${f.name}`,
+      file: f,
       name: f.name,
       size: f.size,
-      ...inspectFile(f.name),
+      status: 'pending',
     }));
     onChange([...files, ...next]);
-    if (isOrderConfirmed) resetOrderConfirm();
+    if (isOrderConfirmed) resetConfirm();
     if (inputRef.current) inputRef.current.value = '';
   };
 
   const handleRemove = (id: string) => {
     onChange(files.filter((f) => f.id !== id));
-    if (isOrderConfirmed) resetOrderConfirm();
+    if (isOrderConfirmed) resetConfirm();
   };
 
   const handleReorder = (next: UploadedFile[]) => {
     onChange(next);
   };
 
-  const handleToggleConfirm = () => {
-    const next = !isOrderConfirmed;
-    setIsOrderConfirmed(next);
-    onOrderConfirmChange(next);
+  const handleConfirm = async () => {
+    if (isOrderConfirmed) {
+      resetConfirm();
+      return;
+    }
+
+    setIsScanning(true);
+    setScanError(null);
+    setIsErrorExpanded(false);
+    onChange(files.map((f) => ({ ...f, status: 'loading' })));
+
+    try {
+      const merged = await mergeFilesToPdf(files.map((f) => f.file));
+      const sessionId = await scanDocument(config.key, merged);
+
+      onChange(files.map((f) => ({ ...f, status: 'safe' })));
+
+      if (config.key === 'registry') {
+        saveRegistrySessionId(sessionId);
+      } else {
+        saveContractSessionId(sessionId);
+      }
+
+      onScanSuccess(config.key, sessionId);
+      setIsOrderConfirmed(true);
+      onOrderConfirmChange(true);
+    } catch (error) {
+      const apiError = error as ApiError;
+      onChange(files.map((f) => ({ ...f, status: 'error' })));
+
+      if (apiError.code === 'PII_DETECTED') {
+        setScanError({
+          code: 'PII_DETECTED',
+          message: apiError.message,
+          nonMasked: apiError.nonMasked ?? [],
+        });
+      } else {
+        setScanError({ code: apiError.code, message: apiError.message });
+      }
+    } finally {
+      setIsScanning(false);
+    }
   };
 
-  const showConfirmButton = files.length > 1;
+  const showConfirmButton = files.length > 0;
 
   return (
     <StyledCard>
@@ -112,7 +166,7 @@ export function FileUploaderCard({
             files={files}
             onRemove={handleRemove}
             onReorder={handleReorder}
-            isLocked={isOrderConfirmed}
+            isLocked={isOrderConfirmed || isScanning}
           />
         )}
 
@@ -121,6 +175,7 @@ export function FileUploaderCard({
             variant={isOrderConfirmed ? 'outline' : 'primary'}
             size="sm"
             width="100%"
+            disabled={isScanning}
             iconStart={
               isOrderConfirmed ? (
                 <Lock
@@ -136,10 +191,50 @@ export function FileUploaderCard({
                 />
               )
             }
-            onClick={handleToggleConfirm}
+            onClick={handleConfirm}
           >
-            {isOrderConfirmed ? '순서 변경하기' : '이 순서로 확정하기'}
+            {isScanning
+              ? '분석 중...'
+              : isOrderConfirmed
+                ? '순서 변경하기'
+                : '이 순서로 확정하기'}
           </Button>
+        )}
+
+        {scanError && (
+          <ErrorArea>
+            <ErrorRow>
+              <TriangleAlert
+                size={ALERT_ICON_SIZE}
+                strokeWidth={ALERT_ICON_STROKE}
+                aria-hidden="true"
+              />
+              <ErrorMessage>{scanError.message}</ErrorMessage>
+              {scanError.code === 'PII_DETECTED' && (
+                <AlertToggleButton
+                  type="button"
+                  aria-label="감지된 항목 보기"
+                  aria-expanded={isErrorExpanded}
+                  onClick={() => setIsErrorExpanded((prev) => !prev)}
+                >
+                  <CircleAlert
+                    size={ALERT_ICON_SIZE}
+                    strokeWidth={ALERT_ICON_STROKE}
+                    aria-hidden="true"
+                  />
+                </AlertToggleButton>
+              )}
+            </ErrorRow>
+            {isErrorExpanded &&
+              scanError.code === 'PII_DETECTED' &&
+              'nonMasked' in scanError && (
+                <IssueList>
+                  {scanError.nonMasked.map((item: string) => (
+                    <IssueItem key={item}>{item}</IssueItem>
+                  ))}
+                </IssueList>
+              )}
+          </ErrorArea>
         )}
       </Body>
     </StyledCard>
@@ -166,4 +261,71 @@ const Body = styled.div`
 
 const HiddenInput = styled.input`
   display: none;
+`;
+
+const ErrorArea = styled.div`
+  border-radius: ${({ theme }) => theme.radius.md};
+  border: 1px solid ${({ theme }) => theme.colors.dangerLight};
+  background: ${({ theme }) => theme.colors.dangerBg};
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const ErrorRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: ${({ theme }) => theme.colors.danger};
+`;
+
+const ErrorMessage = styled.p`
+  flex: 1;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.danger};
+`;
+
+const AlertToggleButton = styled.button`
+  width: 24px;
+  height: 24px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.danger};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s;
+
+  &:hover:not(:disabled),
+  &:active:not(:disabled) {
+    background: ${({ theme }) => theme.colors.dangerLight};
+  }
+`;
+
+const IssueList = styled.div`
+  border-top: 1px dashed ${({ theme }) => theme.colors.dangerLight};
+  padding-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const IssueItem = styled.p`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.textSub};
+
+  &::before {
+    content: '';
+    width: 5px;
+    height: 5px;
+    border-radius: ${({ theme }) => theme.radius.full};
+    background: ${({ theme }) => theme.colors.danger};
+    flex-shrink: 0;
+  }
 `;

--- a/src/constants/uploadedFile.ts
+++ b/src/constants/uploadedFile.ts
@@ -1,14 +1,14 @@
 import type { LucideIcon } from 'lucide-react';
 import { File, Signature } from 'lucide-react';
 
-export type FileStatus = 'ok' | 'warning';
+export type FileStatus = 'pending' | 'loading' | 'safe' | 'error';
 
 export interface UploadedFile {
   id: string;
+  file: File;
   name: string;
   size: number;
   status: FileStatus;
-  issues: string[];
 }
 
 export type UploaderKey = 'registry' | 'contract';
@@ -35,15 +35,4 @@ export const UPLOADER_CONFIGS: UploaderConfig[] = [
   },
 ];
 
-export const PRIVACY_ISSUE_KEYS = [
-  '주민등록번호',
-  '연락처',
-  '계좌번호',
-  '이메일',
-  '생년월일',
-] as const;
-
 export type FileMap = Record<UploaderKey, UploadedFile[]>;
-
-export const PRIVACY_WARNING_MESSAGE =
-  '개인정보 마스킹이 필요한 파일이 있어요.\n카드의 ⓘ 아이콘을 눌러 확인해주세요.';

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -14,6 +14,7 @@ import type {
 } from '../../constants/uploadedFile';
 import { initAnalysis } from '../../api/analyzing';
 import { getApiErrorMessage, type ApiError } from '../../api/error';
+import { saveAnalysisSessionId } from '../../utils/analysisStorage';
 
 const INPUT_STEPS = ['address', 'contract', 'upload'] as const;
 
@@ -51,7 +52,12 @@ export function InputPage() {
   const [orderConfirmed, setOrderConfirmed] = useState<OrderConfirmMap>(
     INITIAL_ORDER_CONFIRMED,
   );
-  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [analysisSessionId, setAnalysisSessionId] = useState<string | null>(
+    null,
+  );
+  const [scanSessionIds, setScanSessionIds] = useState<
+    Partial<Record<UploaderKey, string>>
+  >({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
 
@@ -59,9 +65,6 @@ export function InputPage() {
 
   const isAddressStepNextDisabled = selectedAddress === null;
 
-  const hasWarningFiles = Object.values(files).some((list) =>
-    list.some((f) => f.status === 'warning'),
-  );
   const hasMultiPageFiles = Object.values(files).some(
     (list) => list.length > 1,
   );
@@ -70,9 +73,12 @@ export function InputPage() {
   );
   const isContractStepNextDisabled = isSubmitting;
 
+  const isBothScanned =
+    scanSessionIds.registry !== undefined &&
+    scanSessionIds.contract !== undefined;
+
   const isUploadStepNextDisabled =
-    !sessionId ||
-    (hasWarningFiles && !isMaskingConfirmed) ||
+    !isBothScanned ||
     !isOwnerVerifyConfirmed ||
     (hasMultiPageFiles && !isOrderConfirmed);
 
@@ -100,7 +106,8 @@ export function InputPage() {
         },
       });
 
-      setSessionId(id);
+      saveAnalysisSessionId(id);
+      setAnalysisSessionId(id);
       setCurrentStepIndex((prev) => Math.min(prev + 1, INPUT_STEPS.length - 1));
     } catch (error) {
       setSubmitError(getApiErrorMessage(error as ApiError));
@@ -110,8 +117,8 @@ export function InputPage() {
   };
 
   const handleUploadNext = () => {
-    if (!sessionId) return;
-    navigate('/analyze', { state: { sessionId } });
+    if (!analysisSessionId) return;
+    navigate('/analyze', { state: { sessionId: analysisSessionId } });
   };
 
   const handleNext = () => {
@@ -123,12 +130,15 @@ export function InputPage() {
   };
 
   const handleFilesChange = (key: UploaderKey, next: UploadedFile[]) => {
-    if (next.length > files[key].length) setIsMaskingConfirmed(false);
     setFiles((prev) => ({ ...prev, [key]: next }));
   };
 
   const handleOrderConfirmChange = (key: UploaderKey, confirmed: boolean) => {
     setOrderConfirmed((prev) => ({ ...prev, [key]: confirmed }));
+  };
+
+  const handleScanSuccess = (key: UploaderKey, id: string) => {
+    setScanSessionIds((prev) => ({ ...prev, [key]: id }));
   };
 
   return (
@@ -200,6 +210,7 @@ export function InputPage() {
             files={files}
             onFilesChange={handleFilesChange}
             onOrderConfirmChange={handleOrderConfirmChange}
+            onScanSuccess={handleScanSuccess}
             isMaskingConfirmed={isMaskingConfirmed}
             onMaskingConfirmChange={setIsMaskingConfirmed}
             isOwnerVerifyConfirmed={isOwnerVerifyConfirmed}

--- a/src/pages/InputPage/UploadSection.tsx
+++ b/src/pages/InputPage/UploadSection.tsx
@@ -12,6 +12,7 @@ interface UploadSectionProps {
   files: FileMap;
   onFilesChange: (key: UploaderKey, files: UploadedFile[]) => void;
   onOrderConfirmChange: (key: UploaderKey, confirmed: boolean) => void;
+  onScanSuccess: (key: UploaderKey, sessionId: string) => void;
   isMaskingConfirmed: boolean;
   onMaskingConfirmChange: (confirmed: boolean) => void;
   isOwnerVerifyConfirmed: boolean;
@@ -22,6 +23,7 @@ export function UploadSection({
   files,
   onFilesChange,
   onOrderConfirmChange,
+  onScanSuccess,
   isMaskingConfirmed,
   onMaskingConfirmChange,
   isOwnerVerifyConfirmed,
@@ -33,6 +35,7 @@ export function UploadSection({
         files={files}
         onFilesChange={onFilesChange}
         onOrderConfirmChange={onOrderConfirmChange}
+        onScanSuccess={onScanSuccess}
         isMaskingConfirmed={isMaskingConfirmed}
         onMaskingConfirmChange={onMaskingConfirmChange}
       />

--- a/src/utils/analysisStorage.ts
+++ b/src/utils/analysisStorage.ts
@@ -1,6 +1,8 @@
 import type { ResultData } from '../types/result';
 
 const ANALYSIS_SESSION_ID_KEY = 'analysisSessionId';
+const REGISTRY_SESSION_ID_KEY = 'registrySessionId';
+const CONTRACT_SESSION_ID_KEY = 'contractSessionId';
 const ANALYSIS_RESULT_KEY = 'analysisResult';
 
 export function saveAnalysisSessionId(sessionId: string) {
@@ -9,6 +11,22 @@ export function saveAnalysisSessionId(sessionId: string) {
 
 export function getAnalysisSessionId() {
   return sessionStorage.getItem(ANALYSIS_SESSION_ID_KEY);
+}
+
+export function saveRegistrySessionId(sessionId: string) {
+  sessionStorage.setItem(REGISTRY_SESSION_ID_KEY, sessionId);
+}
+
+export function getRegistrySessionId() {
+  return sessionStorage.getItem(REGISTRY_SESSION_ID_KEY);
+}
+
+export function saveContractSessionId(sessionId: string) {
+  sessionStorage.setItem(CONTRACT_SESSION_ID_KEY, sessionId);
+}
+
+export function getContractSessionId() {
+  return sessionStorage.getItem(CONTRACT_SESSION_ID_KEY);
 }
 
 export function saveAnalysisResult(result: ResultData) {
@@ -29,5 +47,7 @@ export function getAnalysisResultFromStorage() {
 
 export function clearAnalysisStorage() {
   sessionStorage.removeItem(ANALYSIS_SESSION_ID_KEY);
+  sessionStorage.removeItem(REGISTRY_SESSION_ID_KEY);
+  sessionStorage.removeItem(CONTRACT_SESSION_ID_KEY);
   sessionStorage.removeItem(ANALYSIS_RESULT_KEY);
 }

--- a/src/utils/mergeFilesToPdf.ts
+++ b/src/utils/mergeFilesToPdf.ts
@@ -1,0 +1,66 @@
+import { PDFDocument } from 'pdf-lib';
+
+async function readAsArrayBuffer(file: File): Promise<ArrayBuffer> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+async function appendImageToPdf(pdfDoc: PDFDocument, file: File) {
+  const bytes = await readAsArrayBuffer(file);
+
+  if (file.type === 'image/jpeg') {
+    const image = await pdfDoc.embedJpg(bytes);
+    const page = pdfDoc.addPage([image.width, image.height]);
+    page.drawImage(image, {
+      x: 0,
+      y: 0,
+      width: image.width,
+      height: image.height,
+    });
+    return;
+  }
+
+  if (file.type === 'image/png') {
+    const image = await pdfDoc.embedPng(bytes);
+    const page = pdfDoc.addPage([image.width, image.height]);
+    page.drawImage(image, {
+      x: 0,
+      y: 0,
+      width: image.width,
+      height: image.height,
+    });
+    return;
+  }
+}
+
+async function appendPdfToPdf(pdfDoc: PDFDocument, file: File) {
+  const bytes = await readAsArrayBuffer(file);
+  const src = await PDFDocument.load(bytes);
+  const pages = await pdfDoc.copyPages(src, src.getPageIndices());
+  pages.forEach((page) => pdfDoc.addPage(page));
+}
+
+export async function mergeFilesToPdf(files: File[]): Promise<File> {
+  if (files.length === 1 && files[0].type === 'application/pdf') {
+    return files[0];
+  }
+
+  const pdfDoc = await PDFDocument.create();
+
+  for (const file of files) {
+    if (file.type === 'application/pdf') {
+      await appendPdfToPdf(pdfDoc, file);
+    } else {
+      await appendImageToPdf(pdfDoc, file);
+    }
+  }
+
+  const bytes = await pdfDoc.save();
+  return new File([new Uint8Array(bytes)], 'merged.pdf', {
+    type: 'application/pdf',
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,6 +685,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pdf-lib/standard-fonts@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@pdf-lib/standard-fonts@npm:1.0.0"
+  dependencies:
+    pako: "npm:^1.0.6"
+  checksum: 10c0/c683adfb764cd235a8370a0c1d5a8d7e90e3499ad33cdecfb92e4d48b0d36cfd038e3a875ebd0937a5646ee1578d793ab98f9c374be360c9a05d2699c1caedf4
+  languageName: node
+  linkType: hard
+
+"@pdf-lib/upng@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@pdf-lib/upng@npm:1.0.1"
+  dependencies:
+    pako: "npm:^1.0.10"
+  checksum: 10c0/9c300c513c1089e561c0cccac01f396a24efb9b0e9c922a39248cb09dfced70c05b9facdfce11a7f22cbedb4129593630a18111b90a57ef34ea4c3df98f2ac1d
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm64@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.15"
@@ -1672,6 +1690,7 @@ __metadata:
     husky: "npm:^9.1.7"
     lint-staged: "npm:^16.4.0"
     lucide-react: "npm:^1.12.0"
+    pdf-lib: "npm:^1.17.1"
     prettier: "npm:^3.8.1"
     react: "npm:^19.2.4"
     react-datepicker: "npm:^9.1.0"
@@ -3191,6 +3210,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:^1.0.10, pako@npm:^1.0.11, pako@npm:^1.0.6":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 10c0/86dd99d8b34c3930345b8bbeb5e1cd8a05f608eeb40967b293f72fe469d0e9c88b783a8777e4cc7dc7c91ce54c5e93d88ff4b4f060e6ff18408fd21030d9ffbe
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -3254,6 +3280,18 @@ __metadata:
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
+"pdf-lib@npm:^1.17.1":
+  version: 1.17.1
+  resolution: "pdf-lib@npm:1.17.1"
+  dependencies:
+    "@pdf-lib/standard-fonts": "npm:^1.0.0"
+    "@pdf-lib/upng": "npm:^1.0.1"
+    pako: "npm:^1.0.11"
+    tslib: "npm:^1.11.1"
+  checksum: 10c0/a9489a402880dacd1389a3e14ff8f6139d58e3bc82f26b0fcbd0798b841aee6ccb7fcfab0992b574e57b40404ced0330a7170b3c6467363461a9df5d9daec489
   languageName: node
   linkType: hard
 
@@ -3882,6 +3920,13 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^1.11.1":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: 10c0/69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #83 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 2h 30m
- 실제 작업 시간 : 4h 30m

이슈 스펙 기준으로 파일 카드별 개별 전송 + 카드별 에러 표시 구조로 먼저 구현했으나, 
API 명세 확인 후 요청 단위가 섹션 단위(파일 병합 후 단일 전송)임을 파악했습니다.  
파일별 에러 UI를 걷어내고 카드 레벨 단일 에러 영역으로 재구현하는 방향을 팀 회의 끝에 확정하여 시간이 추가로 소요됐습니다.

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

### 요약

- 순서 확정 버튼 클릭 시 파일들을 단일 PDF로 병합 후 OCR API 호출하도록 구현 (`pdf-lib` 의존성 추가)
- OCR 결과 에러 표시 위치를 파일 카드별 → 순서 확정 버튼 아래 카드 레벨 단일 영역으로 변경
- `registrySessionId`, `contractSessionId`, `analysisSessionId` sessionStorage 저장 연결
- 분석 시작 버튼 활성화 조건을 두 섹션 모두 스캔 성공으로 강화

### 파일별 변경 내용

- `documentApi.ts` — `scanRegistry()`, `scanContract()` 함수 구현 (`/documents/ocr/registry`, `/documents/ocr/contract`)
- `mergeFilesToPdf.ts` — 여러 파일(jpg/png/pdf)을 단일 PDF로 병합하는 유틸 추가
- `analysisStorage.ts` — `registrySessionId`, `contractSessionId` sessionStorage 저장/조회/삭제 함수 추가
- `FileUploaderCard.tsx` — 순서 확정 버튼 클릭 시 파일 병합 → OCR API 호출 → sessionStorage 저장 흐름 구현
- `FileItemCard.tsx` — 파일 카드별 상태를 `pending | loading | safe | error`로 정리, warning 관련 UI 제거
- `InputPage.tsx` — 분석 시작 버튼 활성화 조건을 두 섹션 모두 스캔 성공(`scanSessionIds.registry && scanSessionIds.contract`)으로 변경, `analysisSessionId` sessionStorage 저장 연결

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="960" height="699" alt="시연" src="https://github.com/user-attachments/assets/22ef3811-a0f8-45bd-bb1a-6273eee88297" />

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### 에러 표시 위치를 파일 카드별 영역에서 카드 단위 공통 영역으로 변경

- **문제**: 기존 이슈 스펙은 `PII_DETECTED` 발생 시 각 파일 카드에 `i` 버튼과 이슈 패널을 노출하는 구조였습니다. 하지만 순서 확정 버튼 클릭 시 파일들을 하나의 PDF로 병합해 한 번에 전송하는 방식이기 때문에, 응답이 파일 단위가 아닌 요청 단위로 돌아옵니다. 따라서 특정 파일 카드에 에러를 연결할 근거가 부족했습니다.
- **해결**: 에러 표시 영역을 순서 확정 버튼 아래의 카드 단위 공통 영역으로 이동했습니다. `PII_DETECTED`일 때만 `i` 버튼을 노출해 `nonMasked` 항목(주민등록번호, 전화번호 등)을 토글로 확인할 수 있도록 했고, `OCR_FAILED`일 때는 재업로드 안내 문구만 표시하도록 구성했습니다.
- **결과**: 파일 병합 후 단일 요청으로 처리되는 현재 구조에 맞는 에러 UX를 제공하면서, 사용자가 어떤 개인정보 항목을 추가로 가려야 하는지 명확히 확인할 수 있게 됐습니다.

### 분석 시작 버튼 활성화 조건 보완

- **문제**: 기존에는 `sessionId`를 하나의 state로 관리하고 있어, 등기부등본과 임대차계약서 중 하나만 스캔에 성공해도 분석 시작 버튼이 활성화되는 문제가 있었습니다.
- **해결**: `scanSessionIds: Partial<Record<UploaderKey, string>>` 구조로 문서별 `sessionId`를 관리하도록 변경하고, `registry`와 `contract`의 `sessionId`가 모두 존재할 때만 버튼이 활성화되도록 조건을 수정했습니다.
- **결과**: 두 문서가 모두 정상적으로 스캔된 상태에서만 분석을 시작할 수 있어, 불완전한 분석 요청을 방지할 수 있게 됐습니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- `mergeFilesToPdf`에서 이미지(jpg/png)를 PDF 페이지로 변환할 때 우선은 원본 해상도 그대로 사용하고 있습니다!
- `PrivacyMaskingToggle`이 warning 조건 없이 항상 표시되도록 변경했습니다. 동의 확인 UX 의도와 맞는지 확인 부탁드립니다!

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.
