### PR TITLE
[feat] 분석 실행 API 연동 및 업로드 단계 흐름 완성 (#84)

### DIFF
--- a/src/api/analyzing.ts
+++ b/src/api/analyzing.ts
@@ -39,6 +39,21 @@ export async function initAnalysis(
   return data.data.sessionId;
 }
 
+interface RunAnalysisRequest {
+  sessionId: string;
+  registrySessionId: string;
+  contractSessionId: string;
+  ownerVerified: boolean;
+}
+
+interface RunAnalysisResponse {
+  status: 'success';
+}
+
+export async function runAnalysis(request: RunAnalysisRequest): Promise<void> {
+  await apiClient.post<RunAnalysisResponse>('/analysis/run', request);
+}
+
 export function createAnalysisStream(sessionId: string) {
   const encodedSessionId = encodeURIComponent(sessionId);
 

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '../../components/common/Button';
 import { AddressSection } from './AddressSection';
@@ -12,9 +12,15 @@ import type {
   UploadedFile,
   UploaderKey,
 } from '../../constants/uploadedFile';
-import { initAnalysis } from '../../api/analyzing';
+import { initAnalysis, runAnalysis } from '../../api/analyzing';
 import { getApiErrorMessage, type ApiError } from '../../api/error';
-import { saveAnalysisSessionId } from '../../utils/analysisStorage';
+import {
+  saveAnalysisSessionId,
+  getAnalysisSessionId,
+  getRegistrySessionId,
+  getContractSessionId,
+  clearAnalysisStorage,
+} from '../../utils/analysisStorage';
 
 const INPUT_STEPS = ['address', 'contract', 'upload'] as const;
 
@@ -52,14 +58,15 @@ export function InputPage() {
   const [orderConfirmed, setOrderConfirmed] = useState<OrderConfirmMap>(
     INITIAL_ORDER_CONFIRMED,
   );
-  const [analysisSessionId, setAnalysisSessionId] = useState<string | null>(
-    null,
-  );
   const [scanSessionIds, setScanSessionIds] = useState<
     Partial<Record<UploaderKey, string>>
   >({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
+
+  useEffect(() => {
+    clearAnalysisStorage();
+  }, []);
 
   const currentStep = INPUT_STEPS[currentStepIndex];
 
@@ -80,7 +87,8 @@ export function InputPage() {
   const isUploadStepNextDisabled =
     !isBothScanned ||
     !isOwnerVerifyConfirmed ||
-    (hasMultiPageFiles && !isOrderConfirmed);
+    (hasMultiPageFiles && !isOrderConfirmed) ||
+    isSubmitting;
 
   const handleContractNext = async () => {
     if (!selectedAddress || !startDate || !endDate) return;
@@ -107,7 +115,6 @@ export function InputPage() {
       });
 
       saveAnalysisSessionId(id);
-      setAnalysisSessionId(id);
       setCurrentStepIndex((prev) => Math.min(prev + 1, INPUT_STEPS.length - 1));
     } catch (error) {
       setSubmitError(getApiErrorMessage(error as ApiError));
@@ -116,9 +123,29 @@ export function InputPage() {
     }
   };
 
-  const handleUploadNext = () => {
-    if (!analysisSessionId) return;
-    navigate('/analyze', { state: { sessionId: analysisSessionId } });
+  const handleUploadNext = async () => {
+    const sessionId = getAnalysisSessionId();
+    const registrySessionId = getRegistrySessionId();
+    const contractSessionId = getContractSessionId();
+
+    if (!sessionId || !registrySessionId || !contractSessionId) return;
+
+    setIsSubmitting(true);
+    setSubmitError('');
+
+    try {
+      await runAnalysis({
+        sessionId,
+        registrySessionId,
+        contractSessionId,
+        ownerVerified: isOwnerVerifyConfirmed,
+      });
+      navigate('/analyze', { state: { sessionId } });
+    } catch (error) {
+      setSubmitError(getApiErrorMessage(error as ApiError));
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleNext = () => {
@@ -217,6 +244,8 @@ export function InputPage() {
             onOwnerVerifyConfirmChange={setIsOwnerVerifyConfirmed}
           />
 
+          {submitError && <ErrorText>{submitError}</ErrorText>}
+
           <ButtonArea>
             <Button
               variant="outline"
@@ -234,7 +263,7 @@ export function InputPage() {
               onClick={handleUploadNext}
               disabled={isUploadStepNextDisabled}
             >
-              다음: 분석 시작하기
+              {isSubmitting ? '분석 준비 중...' : '다음: 분석 시작하기'}
             </Button>
           </ButtonArea>
         </>


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #84 

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 :
- 실제 작업 시간 :

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

### 요약
- 업로드 단계 완료 후 `/analysis/run` API를 호출하고 분석 페이지로 이동하는 흐름을 구현
- InputPage 재진입 시 이전 분석 세션 데이터가 남지 않도록 초기화 처리를 추가했습니다.

## 파일 별 변경 사항
- `analyzing.ts`
  - `RunAnalysisRequest`, `RunAnalysisResponse` 타입 정의
  - `/analysis/run` POST 요청 `runAnalysis` 함수 구현
- `InputPage.tsx`
  - `handleUploadNext`를 async로 변경, `runAnalysis` 호출 후 분석 페이지로 이동
  - `analysisSessionId` state 제거 → sessionStorage(`getAnalysisSessionId`)에서 직접 조회
  - 마운트 시 `clearAnalysisStorage()` 호출로 이전 분석 데이터 초기화
  - 제출 중 버튼 비활성화(`isSubmitting`) 및 로딩 텍스트(`분석 준비 중...`) 표시
  - 에러 발생 시 `ErrorText`로 인라인 표시

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### `analysisSessionId` state 제거

- 문제: `handleContractNext`에서 `initAnalysis` 응답을 받아 `setAnalysisSessionId(id)`로 state에 저장하고, `handleUploadNext`에서 꺼내 쓰는 구조였습니다. 두 핸들러가 state를 통해 암묵적으로 결합되어 있어, 페이지 새로고침 시 sessionId가 사라지고 분석 실행이 불가능했습니다.
- 해결: `initAnalysis` 응답을 이미 sessionStorage에 저장하고 있었으므로(`saveAnalysisSessionId`), state를 제거하고 `handleUploadNext` 시점에 `getAnalysisSessionId()`로 직접 조회하도록 변경했습니다.
- 결과: state 의존성이 사라져 두 핸들러가 독립적으로 동작하며, 새로고침 후에도 sessionId가 유지됩니다.

### 이전 분석 데이터 초기화 타이밍

- 문제: 결과 페이지가 새로고침 대응을 위해 sessionId와 analysisResult를 sessionStorage에 유지합니다. 이 상태에서 홈으로 돌아갔다가 다시 InputPage에 진입하면 이전 분석의 세션 데이터가 그대로 남아, 새 분석 시 잘못된 sessionId로 요청이 전송될 수 있었습니다.
- 해결: InputPage 마운트 시점(`useEffect(() => { clearAnalysisStorage(); }, [])`)에 sessionStorage를 전체 초기화하도록 했습니다.
- 결과: 새 분석을 시작할 때마다 이전 세션 데이터가 깨끗이 제거되어 세션 충돌 없이 분석을 진행할 수 있습니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.
