### PR TITLE
[hotfix] 백엔드 계약 유형 enum에 맞추고 주소 입력 상태 동기화

### DIFF
--- a/src/constants/contract.ts
+++ b/src/constants/contract.ts
@@ -1,7 +1,7 @@
-export type ContractType = 'jeonse' | 'halfJeonse' | 'monthlyRent';
+export type ContractType = 'jeonse' | 'half_jeonse' | 'monthly';
 
 export const CONTRACT_TYPES = [
   { value: 'jeonse', label: '전세' },
-  { value: 'halfJeonse', label: '반전세' },
-  { value: 'monthlyRent', label: '월세' },
+  { value: 'half_jeonse', label: '반전세' },
+  { value: 'monthly', label: '월세' },
 ] as const;

--- a/src/hooks/useAddressSearch.ts
+++ b/src/hooks/useAddressSearch.ts
@@ -7,8 +7,7 @@ import type { ApiError } from '../api/error';
 const FIRST_PAGE = 1;
 const PAGE_SIZE = 10;
 
-export function useAddressSearch() {
-  const [keyword, setKeyword] = useState('');
+export function useAddressSearch(keyword: string) {
   const [searchedKeyword, setSearchedKeyword] = useState('');
   const [currentAddresses, setCurrentAddresses] = useState<Address[]>([]);
   const [currentPage, setCurrentPage] = useState(FIRST_PAGE);
@@ -67,8 +66,6 @@ export function useAddressSearch() {
   }, [currentPage, hasNextPage, isFetchingMore, isLoading, searchedKeyword]);
 
   return {
-    keyword,
-    setKeyword,
     isSearched,
     currentAddresses,
     hasNextPage,

--- a/src/pages/InputPage/AddressSection.tsx
+++ b/src/pages/InputPage/AddressSection.tsx
@@ -1,18 +1,20 @@
+import { useEffect } from 'react';
+import styled from '@emotion/styled';
+
 import { Card } from '../../components/common/Card';
 import { useAddressSearch } from '../../hooks/useAddressSearch';
 import type { Address } from '../../types/address';
 import { AddressSearchInput } from '../../components/feature/InputPage/AddressSection/AddressSearchInput';
 import { AddressSearchResult } from '../../components/feature/InputPage/AddressSection/AddressSearchResult';
-import styled from '@emotion/styled';
 
 interface AddressSectionProps {
   selectedAddress: Address | null;
-  onSelect: (address: Address) => void;
+  onSelectAddress: (address: Address) => void;
 }
 
 export function AddressSection({
   selectedAddress,
-  onSelect,
+  onSelectAddress,
 }: AddressSectionProps) {
   const {
     keyword,
@@ -27,8 +29,14 @@ export function AddressSection({
     errorMessage,
   } = useAddressSearch();
 
+  useEffect(() => {
+    if (selectedAddress) {
+      setKeyword(selectedAddress.roadAddress);
+    }
+  }, [selectedAddress, setKeyword]);
+
   const handleSelectAddress = (address: Address) => {
-    onSelect(address);
+    onSelectAddress(address);
     setKeyword(address.roadAddress);
   };
 

--- a/src/pages/InputPage/AddressSection.tsx
+++ b/src/pages/InputPage/AddressSection.tsx
@@ -1,24 +1,24 @@
-import { useEffect } from 'react';
-import styled from '@emotion/styled';
-
 import { Card } from '../../components/common/Card';
 import { useAddressSearch } from '../../hooks/useAddressSearch';
 import type { Address } from '../../types/address';
 import { AddressSearchInput } from '../../components/feature/InputPage/AddressSection/AddressSearchInput';
 import { AddressSearchResult } from '../../components/feature/InputPage/AddressSection/AddressSearchResult';
+import styled from '@emotion/styled';
 
 interface AddressSectionProps {
   selectedAddress: Address | null;
-  onSelectAddress: (address: Address) => void;
+  onSelectAddress: (address: Address | null) => void;
+  keyword: string;
+  onChangeKeyword: (keyword: string) => void;
 }
 
 export function AddressSection({
   selectedAddress,
   onSelectAddress,
+  keyword,
+  onChangeKeyword,
 }: AddressSectionProps) {
   const {
-    keyword,
-    setKeyword,
     isSearched,
     currentAddresses,
     hasNextPage,
@@ -27,17 +27,19 @@ export function AddressSection({
     isLoading,
     isFetchingMore,
     errorMessage,
-  } = useAddressSearch();
+  } = useAddressSearch(keyword);
 
-  useEffect(() => {
-    if (selectedAddress) {
-      setKeyword(selectedAddress.roadAddress);
+  const handleChangeKeyword = (nextKeyword: string) => {
+    onChangeKeyword(nextKeyword);
+
+    if (selectedAddress && nextKeyword !== selectedAddress.roadAddress) {
+      onSelectAddress(null);
     }
-  }, [selectedAddress, setKeyword]);
+  };
 
   const handleSelectAddress = (address: Address) => {
     onSelectAddress(address);
-    setKeyword(address.roadAddress);
+    onChangeKeyword(address.roadAddress);
   };
 
   return (
@@ -46,7 +48,7 @@ export function AddressSection({
 
       <AddressSearchInput
         keyword={keyword}
-        onChangeKeyword={setKeyword}
+        onChangeKeyword={handleChangeKeyword}
         onSearch={handleSearch}
       />
 

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -63,7 +63,7 @@ export function InputPage() {
   >({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
-
+  const [addressKeyword, setAddressKeyword] = useState('');
   useEffect(() => {
     clearAnalysisStorage();
   }, []);
@@ -175,6 +175,8 @@ export function InputPage() {
           <AddressSection
             selectedAddress={selectedAddress}
             onSelectAddress={setSelectedAddress}
+            keyword={addressKeyword}
+            onChangeKeyword={setAddressKeyword}
           />
 
           <ButtonArea>

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -174,7 +174,7 @@ export function InputPage() {
         <>
           <AddressSection
             selectedAddress={selectedAddress}
-            onSelect={setSelectedAddress}
+            onSelectAddress={setSelectedAddress}
           />
 
           <ButtonArea>


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #이슈번호

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1.5h
- 실제 작업 시간 : 1.5h

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

1. 계약 유형 값 백엔드 enum과 정합성 맞춤

- 백엔드 /analysis/init 요청에서 허용하는 contractType 값과 프론트에서 보내는 값이 달라 400 에러가 발생하던 문제를 수정

2. 계약 정보 입력 단계 다음 버튼 활성화 조건 추가

- 계약 정보 입력 단계에서 필수 입력값이 비어 있어도 다음 단계로 이동할 수 있던 문제 수정
- 추가로 handleContractNext 내부에도 방어 코드를 넣어 직접 함수가 호출되더라도 잘못된 요청이 나가지 않도록 처리

3. 주소 입력 상태 관리 구조 개선

- 주소 선택 후 계약 정보 단계로 이동했다가 이전 버튼으로 돌아오면, 선택된 주소는 유지되지만 주소 검색 input이 비어 보이는 문제가 있었음

- 원인:

  - 선택된 주소(selectedAddress)는 부모(InputPage) state에서 관리
  - 주소 검색어(keyword)는 useAddressSearch 내부 state에서 관리
  - step 이동 시 AddressSection이 재렌더링되며 keyword가 초기화
  - 결과적으로 선택 상태와 input 표시 상태가 서로 어긋나는 문제 발생

- 해결:
  - 주소 검색어 상태를 useAddressSearch 내부에서 관리하지 않고 InputPage로 끌어올려(state lifting) 선택된 주소와 같은 계층에서 관리하도록 구조 변경

- 이에 따라:
  - selectedAddress
  - addressKeyword
- 두 상태가 부모에서 함께 관리되도록 수정했고, AddressSection은 상태를 직접 가지지 않고 props 기반으로 동작하도록 변경함

- 추가로 사용자가 주소 검색어를 직접 수정할 경우 기존 선택 주소는 초기화되도록 처리해 상태 불일치가 발생하지 않도록 보완

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- [트러블 슈팅1](링크)

- 초기에는 selectedAddress가 존재할 경우 useEffect로 keyword를 다시 동기화하는 방식도 고려했음

- 하지만 이 방식은 상태가 서로 다른 계층에서 관리되는 구조적 문제를 그대로 둔 채 화면 표시만 맞추는 임시 해결에 가깝다고 판단

- 계약 정보 입력값들이 모두 부모 state에서 관리되는 구조와 일관성을 맞추기 위해 주소 검색어 역시 부모로 상태를 올려 단일 source of truth를 갖도록 개선

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 주소 선택 시 검색 키워드가 자동으로 업데이트됩니다.

* **리팩토링**
  * 계약 유형 상수명을 표준화했습니다 (camelCase → snake_case).
  * 주소 선택 관련 컴포넌트 속성명을 개선했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/S1J2-Lab/home-protect-client/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->