### PR TITLE
[hotfix] 전세가율 백엔드 형식에 맞게 수정

### DIFF
--- a/src/components/feature/ResultPage/DetailAnalysis/Jeonse/JeonseRatioCard.tsx
+++ b/src/components/feature/ResultPage/DetailAnalysis/Jeonse/JeonseRatioCard.tsx
@@ -28,9 +28,7 @@ export function JeonseRatioCard({ jeonseRatio }: JeonseRatioCardProps) {
 
   const hasMarketData = (sampleCount ?? 0) > 0;
   const safeRatio = Math.min(Math.max(ratioPercent ?? 0, 0), 100);
-  const notice = hasMarketData
-    ? getRatioNotice(safeRatio)
-    : '최근 거래량이 없어 전세가율을 계산하기 어려워요. 주변 시세를 추가로 확인해 주세요.';
+  const notice = getRatioNotice(riskLevel, sampleCount);
 
   return (
     <AnalysisCard

--- a/src/types/jeonse.ts
+++ b/src/types/jeonse.ts
@@ -1,12 +1,13 @@
 import type { RiskLevel } from './risk';
+
 export interface JeonseRatioData {
   ratioType: 'jeonse' | 'monthly';
-  ratioPercent: number;
-  riskLevel: RiskLevel;
-  recentHigh: number;
-  recentLow: number;
-  average: number;
-  convertedDeposit: number;
+  ratioPercent: number | null;
+  riskLevel: RiskLevel | null;
+  recentHigh: number | null;
+  recentLow: number | null;
+  average: number | null;
+  convertedDeposit: number | null;
   sampleCount: number;
   lowReliability: boolean;
 }

--- a/src/utils/jeonseRatio.ts
+++ b/src/utils/jeonseRatio.ts
@@ -1,17 +1,30 @@
-export function getRatioNotice(ratio: number) {
-  if (ratio <= 75) {
+import type { RiskLevel } from '../types/risk';
+
+export function getRatioNotice(
+  riskLevel: RiskLevel | null,
+  sampleCount: number,
+) {
+  if (sampleCount === 0) {
+    return '최근 거래량이 없어 전세가율을 계산하기 어려워요. 주변 시세를 추가로 확인해 주세요.';
+  }
+
+  if (riskLevel === 'safe') {
     return '전세가율이 안정적인 수준이에요.';
   }
 
-  if (ratio <= 85) {
+  if (riskLevel === 'caution') {
     return '전세가율이 다소 높은 편이에요. 시세와 보증보험 가능 여부를 확인해 주세요.';
   }
 
-  return '전세가율이 매우 높아 깡통전세 위험이 있습니다. 계약 전 반드시 추가 확인이 필요해요.';
+  if (riskLevel === 'danger') {
+    return '전세가율이 매우 높아 깡통전세 위험이 있습니다. 계약 전 반드시 추가 확인이 필요해요.';
+  }
+
+  return '전세가율 정보를 확인하기 어려워요. 주변 시세를 추가로 확인해 주세요.';
 }
 
-export function formatPrice(price: number | null | undefined) {
-  if (price == null) {
+export function formatPrice(price: number | null) {
+  if (price === null) {
     return '정보 없음';
   }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #이슈번호

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 15min
- 실제 작업 시간 : 15min

<br />

## 💻 작업 내용

### 1. 백엔드 전세가율 응답 스펙 반영
- 백엔드 `jeonseRatio` 응답 구조에 맞춰 프론트 타입을 수정했습니다.
- 실제 응답에서 `ratioPercent`, `riskLevel`, 시세 관련 값들이 `null`로 내려올 수 있어 nullable 타입을 반영했습니다.

**변경 필드**
- `ratioPercent`
- `riskLevel`
- `recentHigh`
- `recentLow`
- `average`
- `convertedDeposit`

이를 통해 백엔드 응답 스펙과 프론트 타입 정의를 일치시켰습니다.

---

### 2. 전세가율 안내 문구 로직 개선
- 기존에는 `ratioPercent` 값 기준으로 위험 안내 문구를 프론트에서 직접 계산하고 있었습니다.
- 하지만 백엔드에서 이미 `riskLevel`을 판단해 내려주고 있어, 프론트와 백엔드 판단 기준이 불일치할 수 있었습니다.

**예시**
- `ratioPercent: 72.5`
- `riskLevel: caution`

기존 로직에서는 비율 기준으로 "안정적" 안내 문구가 표시될 수 있었지만,
실제 백엔드 판단은 `caution`인 상황이 발생할 수 있었습니다.

**개선**
- 안내 문구 기준을 `ratioPercent` → `riskLevel` 기반으로 변경
- `sampleCount === 0`인 경우 별도 안내 문구 처리
- `riskLevel: null` fallback 처리 추가



<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- [트러블 슈팅1](링크)

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 거래량 정보 부재 시 오류 처리 개선
  * 데이터 안정성 강화를 위한 null 값 처리 개선

* **Refactor**
  * 위험도 기반 알림 메시지 로직 최적화
  * 가격 표시 기능 안정성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/S1J2-Lab/home-protect-client/pull/107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->