### PR TITLE
[feat] 입력 페이지 이탈 시 데이터 초기화 경고 추가 (#112)

### DIFF
--- a/src/hooks/useBeforeUnload.ts
+++ b/src/hooks/useBeforeUnload.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useBlocker } from 'react-router-dom';
+
+const UNLOAD_MESSAGE =
+  '페이지를 벗어나면 입력한 내용이 모두 초기화됩니다.\n계속하시겠습니까?';
+
+export function useBeforeUnload(isActive: boolean) {
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isActive]);
+
+  const blocker = useBlocker(() => isActive);
+
+  useEffect(() => {
+    if (blocker.state !== 'blocked') return;
+
+    const id = setTimeout(() => {
+      if (window.confirm(UNLOAD_MESSAGE)) {
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
+    }, 0);
+
+    return () => clearTimeout(id);
+  }, [blocker]);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,12 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AppStyleProvider } from './styles/AppStyleProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <AppStyleProvider>
-        <App />
-      </AppStyleProvider>
-    </BrowserRouter>
+    <AppStyleProvider>
+      <App />
+    </AppStyleProvider>
   </StrictMode>,
 );

--- a/src/pages/InputPage/InputPage.tsx
+++ b/src/pages/InputPage/InputPage.tsx
@@ -21,6 +21,7 @@ import {
   getContractSessionId,
   clearAnalysisStorage,
 } from '../../utils/analysisStorage';
+import { useBeforeUnload } from '../../hooks/useBeforeUnload';
 
 const INPUT_STEPS = ['address', 'contract', 'upload'] as const;
 
@@ -64,6 +65,17 @@ export function InputPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
   const [addressKeyword, setAddressKeyword] = useState('');
+
+  const hasInput =
+    selectedAddress !== null ||
+    deposit > 0 ||
+    startDate !== null ||
+    endDate !== null ||
+    files.registry.length > 0 ||
+    files.contract.length > 0;
+
+  useBeforeUnload(hasInput);
+
   useEffect(() => {
     clearAnalysisStorage();
   }, []);

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -1,4 +1,8 @@
-import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  RouterProvider,
+  useNavigate,
+} from 'react-router-dom';
 import { ChevronLeft } from 'lucide-react';
 
 import { LandingPage } from '../pages/LandingPage/LandingPage';
@@ -13,6 +17,7 @@ import { Header } from '../components/common/Header';
 import { StepIndicator } from '../components/common/StepIndicator';
 import { Button } from '../components/common/Button';
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import logoImage from '../assets/logo.png';
 import { HeaderLogo } from '../components/common/HeaderLogo';
@@ -27,107 +32,131 @@ function ScrollToTop() {
   return null;
 }
 
-export function AppRouter() {
+function LandingLayout() {
+  return (
+    <>
+      <ScrollToTop />
+      <Layout
+        header={
+          <Header
+            title="지켜줘홈즈"
+            logo={<HeaderLogo src={logoImage} alt="지켜줘홈즈 로고" />}
+          />
+        }
+        noPadding
+      />
+    </>
+  );
+}
+
+function InputLayout() {
   const navigate = useNavigate();
 
   return (
     <>
       <ScrollToTop />
-      <Routes>
-        <Route
-          element={
-            <Layout
-              header={
-                <Header
-                  title="지켜줘홈즈"
-                  logo={<HeaderLogo src={logoImage} alt="지켜줘홈즈 로고" />}
-                />
-              }
-              noPadding
-            />
-          }
-        >
-          <Route path="/" element={<LandingPage />} />
-        </Route>
-
-        <Route
-          element={
-            <Layout
-              header={
-                <Header
-                  title="정보 입력"
-                  left={
-                    <Button
-                      variant="ghost"
-                      tone="black"
-                      size="lg"
-                      iconStart={<ChevronLeft />}
-                      aria-label="이전"
-                      onClick={() => navigate(-1)}
-                    />
-                  }
-                />
-              }
-              stepIndicator={<StepIndicator currentStep={1} totalSteps={3} />}
-            />
-          }
-        >
-          <Route path="/input" element={<InputPage />} />
-        </Route>
-
-        <Route
-          element={
-            <Layout
-              header={
-                <Header
-                  title="계약 분석 중"
-                  left={
-                    <Button
-                      variant="ghost"
-                      tone="blue"
-                      size="lg"
-                      iconStart={<ChevronLeft />}
-                      aria-label="이전"
-                      onClick={() => navigate(-1)}
-                    />
-                  }
-                />
-              }
-              stepIndicator={<StepIndicator currentStep={2} totalSteps={3} />}
-              noPadding
-            />
-          }
-        >
-          <Route path="/analyze" element={<AnalysisLoadingPage />} />
-        </Route>
-
-        <Route
-          element={
-            <Layout
-              header={
-                <Header
-                  title="분석 결과"
-                  left={
-                    <Button
-                      variant="ghost"
-                      tone="black"
-                      size="lg"
-                      iconStart={<ChevronLeft />}
-                      aria-label="이전"
-                      onClick={() => navigate(-1)}
-                    />
-                  }
-                />
-              }
-              stepIndicator={<StepIndicator currentStep={3} totalSteps={3} />}
-            />
-          }
-        >
-          <Route path="/result" element={<ResultPage />} />
-          <Route path="/result/registry" element={<RegistryDetailPage />} />
-          <Route path="/result/contract" element={<ContractDetailPage />} />
-        </Route>
-      </Routes>
+      <Layout
+        header={
+          <Header
+            title="정보 입력"
+            left={
+              <Button
+                variant="ghost"
+                tone="black"
+                size="lg"
+                iconStart={<ChevronLeft />}
+                aria-label="이전"
+                onClick={() => navigate(-1)}
+              />
+            }
+          />
+        }
+        stepIndicator={<StepIndicator currentStep={1} totalSteps={3} />}
+      />
     </>
   );
+}
+
+function AnalyzingLayout() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <ScrollToTop />
+      <Layout
+        header={
+          <Header
+            title="계약 분석 중"
+            left={
+              <Button
+                variant="ghost"
+                tone="blue"
+                size="lg"
+                iconStart={<ChevronLeft />}
+                aria-label="이전"
+                onClick={() => navigate(-1)}
+              />
+            }
+          />
+        }
+        stepIndicator={<StepIndicator currentStep={2} totalSteps={3} />}
+        noPadding
+      />
+    </>
+  );
+}
+
+function ResultLayout() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <ScrollToTop />
+      <Layout
+        header={
+          <Header
+            title="분석 결과"
+            left={
+              <Button
+                variant="ghost"
+                tone="black"
+                size="lg"
+                iconStart={<ChevronLeft />}
+                aria-label="이전"
+                onClick={() => navigate(-1)}
+              />
+            }
+          />
+        }
+        stepIndicator={<StepIndicator currentStep={3} totalSteps={3} />}
+      />
+    </>
+  );
+}
+
+const router = createBrowserRouter([
+  {
+    element: <LandingLayout />,
+    children: [{ path: '/', element: <LandingPage /> }],
+  },
+  {
+    element: <InputLayout />,
+    children: [{ path: '/input', element: <InputPage /> }],
+  },
+  {
+    element: <AnalyzingLayout />,
+    children: [{ path: '/analyze', element: <AnalysisLoadingPage /> }],
+  },
+  {
+    element: <ResultLayout />,
+    children: [
+      { path: '/result', element: <ResultPage /> },
+      { path: '/result/registry', element: <RegistryDetailPage /> },
+      { path: '/result/contract', element: <ContractDetailPage /> },
+    ],
+  },
+]);
+
+export function AppRouter() {
+  return <RouterProvider router={router} />;
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 연관된 이슈 번호를 적어주세요.
> 이슈를 함께 종료하려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #112

<br />

## ⏰ 작업 시간

> 예상과 실제 시간이 다르다면 이유를 간단히 적어주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1.5h

`useBlocker` 사용을 위한 라우터 마이그레이션이 필요해져 해당 작업으로 인해 조금 시간이 더 걸렸습니당 

<br />

## 💻 작업 내용

> 이번 작업에서 진행한 내용을 정리해주세요.

### 간단 요약
- 입력 페이지에서 새로고침·탭 닫기·뒤로가기 시 데이터 초기화 경고 알림 추가
- `BrowserRouter` → `createBrowserRouter` 마이그레이션 (`useBlocker` 사용을 위한 선행 작업)

### 설명
- `src/hooks/useBeforeUnload.ts` (신규)
  - `isActive: boolean` 파라미터로 활성화 여부 제어
  - `beforeunload` 이벤트: 새로고침·탭 닫기 시 브라우저 기본 경고 팝업
  - `useBlocker`: SPA 내부 뒤로가기(헤더 버튼·브라우저 버튼) 차단 후 `window.confirm()` 표시
  - 확인 → `blocker.proceed()` (이동 허용), 취소 → `blocker.reset()` (현재 페이지 유지)
- `src/pages/InputPage/InputPage.tsx`
  - `hasInput` 조건 추가 (주소·보증금·날짜·파일 중 하나라도 입력 시 `true`)
  - `useBeforeUnload(hasInput)` 적용
- `src/main.tsx`
  - `BrowserRouter` 제거 (라우터 컨텍스트는 `RouterProvider`가 담당)
- `src/routes/AppRouter.tsx`
  - `createBrowserRouter` + `RouterProvider`로 전환
  - 라우트별 레이아웃 컴포넌트 분리 (`LandingLayout`, `InputLayout`, `AnalyzingLayout`, `ResultLayout`)

<br />

> 필요한 경우 스크린샷이나 캡처 화면을 함께 첨부해주세요.

<img width="960" height="665" alt="화면 기록 2026-06-01 오후 7 43 07" src="https://github.com/user-attachments/assets/c9e5d49c-fa6a-4a96-91cd-3c5c73f5b8d7" />

<br />

## 🪏 작업하면서 고민한 부분

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### 이탈 경고 UI 방식 — 커스텀 모달 vs 브라우저 기본 UI

- 문제: 커스텀 모달(Bottom Sheet 등)로 경고 UI를 구현하면 디자인 통일성은 좋지만, `beforeunload`(새로고침·탭 닫기) 시나리오에서는 브라우저 보안 정책상 커스텀 UI 렌더 자체가 차단됩니다.
- 해결: 새로고침·탭 닫기는 `beforeunload` + 브라우저 기본 팝업, 뒤로가기는 `useBlocker` + `window.confirm()`으로 모든 시나리오를 브라우저 기본 UI로 통일했습니다.
- 결과: 시나리오별 UI 불일치 없이 모든 이탈 케이스에서 일관된 경고 동작을 보장합니다.

### `useBlocker` 사용을 위한 라우터 마이그레이션

- 문제: 기존 `BrowserRouter`는 data router context를 제공하지 않아 `useBlocker must be used within a data router` 에러가 발생했습니다.
- 해결: `createBrowserRouter` + `RouterProvider`로 마이그레이션하고, 기존 `<Route element={<Layout .../>}>` 인라인 패턴을 라우트 그룹별 레이아웃 컴포넌트(`LandingLayout`, `InputLayout` 등)로 분리했습니다.
- 결과: `useBlocker`를 포함한 data router API를 사용할 수 있게 됐고, 라우트별 레이아웃 구조도 명시적으로 분리됐습니다.

### `confirm` 실행 타이밍 — `setTimeout` defer

- 문제: `blocker.state === 'blocked'` 전환이 React 렌더 사이클 도중 발생하여 `useEffect` 안에서 `window.confirm()`을 즉시 실행하면 화면이 하얗게 멈추는 현상이 있었습니다.
- 해결: `setTimeout(..., 0)`으로 `confirm` 실행을 다음 태스크로 defer했습니다.
- 결과: 렌더가 완료된 후 팝업이 뜨도록 처리되어 화면이 정상적으로 유지됩니다.

<br />

## 👀 리뷰 포인트

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

- `useBlocker(() => isActive)` — boolean을 직접 넘기지 않고 함수로 감싼 이유: React Router v7에서 boolean을 직접 넘기면 blocker 상태 전환이 불안정하게 동작합니다.
- `setTimeout(..., 0)` defer 처리가 렌더 사이클 문제를 해결하는 방식이 적절한지

<br />

## 📘 참고 자료

> 작업하면서 참고한 문서, 링크, 자료가 있다면 작성해주세요.
- [React Router — useBlocker](https://reactrouter.com/api/hooks/useBlocker)